### PR TITLE
Move everything to net.codingwell per codingwell/scala-guice#8

### DIFF
--- a/src/main/scala/net/codingwell/package.scala
+++ b/src/main/scala/net/codingwell/package.scala
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package uk.me.lings
+package net.codingwell
 
 package object scalaguice {
-    
+
     import com.google.inject._
 
     import java.lang.reflect.Type
-    
+
     private[scalaguice] def typeOf[T](implicit m: Manifest[T]): Type = {
         def toWrapper(c:Type) = c match {
             case java.lang.Byte.TYPE => classOf[java.lang.Byte]
@@ -43,7 +43,7 @@ package object scalaguice {
             }
         }
     }
-    
+
     /**
      * Create a [[com.google.inject.TypeLiteral]] from a [[scala.Manifest]].
      * Subtypes of [[scala.AnyVal]] will be converted to their corresponding
@@ -52,11 +52,11 @@ package object scalaguice {
     def typeLiteral[T : Manifest]: TypeLiteral[T] = {
         TypeLiteral.get(typeOf[T]).asInstanceOf[TypeLiteral[T]]
     }
-    
+
     import java.lang.annotation.{Annotation => JAnnotation}
-    
+
     type AnnotationClass[T <: JAnnotation] = Class[T]
-    
+
     /**
      * Get the class for a Java Annotation using a [[scala.Manifest]].
      */

--- a/src/main/scala/net/codingwell/scalaguice/BindingExtensions.scala
+++ b/src/main/scala/net/codingwell/scalaguice/BindingExtensions.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package uk.me.lings.scalaguice
+package net.codingwell.scalaguice
 
 import com.google.inject._
 
@@ -22,7 +22,7 @@ import com.google.inject._
  * These allow using a type parameter instead of <code>classOf[Foo]}</code>
  * or <code>new TypeLiteral[Bar[Foo]] {}</code>. The extra methods are
  * named as those in the normal binding DSL suffixed with <code>Type</code>.
- * 
+ *
  * For example, instead of
  * {{{
  * binder.bind(new TypeLiteral[Bar[Foo]]{}).to(classOf[FooBarImpl])
@@ -38,52 +38,52 @@ import com.google.inject._
  * manifests for wildcard types don't provide access to type bounds.
  */
 object BindingExtensions {
-    
+
     class ScalaBinder(b:Binder) {
         def bindType[T : Manifest] = b bind typeLiteral[T]
     }
-    
-    implicit def enrichBinder(b:Binder) = new ScalaBinder(b) 
-    
+
+    implicit def enrichBinder(b:Binder) = new ScalaBinder(b)
+
     import com.google.inject.binder._
     import java.lang.annotation.{Annotation => JAnnotation}
-    
+
     class ScalaScopedBindingBuilder(b: ScopedBindingBuilder) {
         def inType[TAnn <: JAnnotation : ClassManifest] = b in annotation[TAnn]
     }
-    
+
     implicit def enrichScopedBindingBuilder(b: ScopedBindingBuilder) = new ScalaScopedBindingBuilder(b)
 
     class ScalaLinkedBindingBuilder[T](b: LinkedBindingBuilder[T]) {
         def toType[TImpl <: T : Manifest] = b to typeLiteral[TImpl]
         def toProviderType[TProvider <: Provider[_ <: T] : ClassManifest] = b toProvider classManifest[TProvider].erasure.asInstanceOf[Class[TProvider]]
     }
-    
-    implicit def enrichLinkedBinding[T](b: LinkedBindingBuilder[T]) = 
+
+    implicit def enrichLinkedBinding[T](b: LinkedBindingBuilder[T]) =
       new ScalaLinkedBindingBuilder[T](b)
-    
+
     class ScalaAnnotatedBindingBuilder[T](b: AnnotatedBindingBuilder[T]) {
-        def annotatedWithType[TAnn <: JAnnotation : ClassManifest] = 
+        def annotatedWithType[TAnn <: JAnnotation : ClassManifest] =
           b annotatedWith annotation[TAnn]
     }
 
-    implicit def enrichAnnotatedBinding[T](b: AnnotatedBindingBuilder[T]) = 
+    implicit def enrichAnnotatedBinding[T](b: AnnotatedBindingBuilder[T]) =
       new ScalaAnnotatedBindingBuilder[T](b)
-    
+
     class ScalaAnnotatedConstantBindingBuilder(b: AnnotatedConstantBindingBuilder) {
-        def annotatedWithType[TAnn <: JAnnotation : ClassManifest] = 
+        def annotatedWithType[TAnn <: JAnnotation : ClassManifest] =
           b annotatedWith annotation[TAnn]
     }
-    
+
     implicit def enrichAnnotatedConstantBindingBuilder(b: AnnotatedConstantBindingBuilder) =
       new ScalaAnnotatedConstantBindingBuilder(b)
 
     class ScalaConstantBindingBuilder(b: ConstantBindingBuilder) {
         def toType[T: ClassManifest] = b to classManifest[T].erasure
     }
-    
+
     implicit def enrichConstantBinding(b: ConstantBindingBuilder) =
       new ScalaConstantBindingBuilder(b)
-    
+
 }
 

--- a/src/main/scala/net/codingwell/scalaguice/InjectorExtensions.scala
+++ b/src/main/scala/net/codingwell/scalaguice/InjectorExtensions.scala
@@ -13,19 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package uk.me.lings.scalaguice
+package net.codingwell.scalaguice
 
-import com.google.inject._
+import com.google.inject.Injector
 
-object KeyExtensions {
+object InjectorExtensions {
 
-    import java.lang.annotation.{Annotation => JAnnotation}
+  import KeyExtensions._
 
-    implicit def enrichTypeLiteral[T](t: TypeLiteral[T]) = new {
-        def toKey: Key[T] = Key.get(t)
-        def annotatedWith(annotation: JAnnotation): Key[T] = Key.get(t, annotation)
-        def annotatedWith[TAnn <: JAnnotation : ClassManifest]:Key[T] = 
-            Key.get(t, annotation[TAnn])
-    }
-        
+  class ScalaInjector(i:Injector) {
+    def instance[T : Manifest] = i.getInstance(typeLiteral[T].toKey)
+  }
+
+  implicit def enrichInjector(i:Injector) = new ScalaInjector(i)
 }

--- a/src/main/scala/net/codingwell/scalaguice/KeyExtensions.scala
+++ b/src/main/scala/net/codingwell/scalaguice/KeyExtensions.scala
@@ -13,17 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package uk.me.lings.scalaguice
+package net.codingwell.scalaguice
 
-import com.google.inject.Injector
+import com.google.inject._
 
-object InjectorExtensions {
-  
-  import KeyExtensions._
-  
-  class ScalaInjector(i:Injector) {
-    def instance[T : Manifest] = i.getInstance(typeLiteral[T].toKey)
-  }
-  
-  implicit def enrichInjector(i:Injector) = new ScalaInjector(i)
+object KeyExtensions {
+
+    import java.lang.annotation.{Annotation => JAnnotation}
+
+    implicit def enrichTypeLiteral[T](t: TypeLiteral[T]) = new {
+        def toKey: Key[T] = Key.get(t)
+        def annotatedWith(annotation: JAnnotation): Key[T] = Key.get(t, annotation)
+        def annotatedWith[TAnn <: JAnnotation : ClassManifest]:Key[T] =
+            Key.get(t, annotation[TAnn])
+    }
+
 }

--- a/src/main/scala/net/codingwell/scalaguice/MultiBinder.scala
+++ b/src/main/scala/net/codingwell/scalaguice/MultiBinder.scala
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package uk.me.lings.scalaguice
+package net.codingwell.scalaguice
 
 import com.google.inject._
 import com.google.inject.multibindings._

--- a/src/main/scala/net/codingwell/scalaguice/ScalaModule.scala
+++ b/src/main/scala/net/codingwell/scalaguice/ScalaModule.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package uk.me.lings.scalaguice
+package net.codingwell.scalaguice
 
 import com.google.inject._
 import binder._

--- a/src/main/scala/net/codingwell/scalaguice/SetProvider.scala
+++ b/src/main/scala/net/codingwell/scalaguice/SetProvider.scala
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package uk.me.lings.scalaguice
+package net.codingwell.scalaguice
 
 import com.google.common.collect.ImmutableSet
 import com.google.inject._

--- a/src/main/scala/net/codingwell/scalaguice/binder/BindingProxies.scala
+++ b/src/main/scala/net/codingwell/scalaguice/binder/BindingProxies.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package uk.me.lings.scalaguice
+package net.codingwell.scalaguice
 package binder
 
 import com.google.inject._

--- a/src/test/scala/net/codingwell/scalaguice/BindingExtensionsSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/BindingExtensionsSpec.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package uk.me.lings.scalaguice
+package net.codingwell.scalaguice
 
 import org.scalatest.WordSpec
 import org.scalatest.matchers.ShouldMatchers
@@ -21,7 +21,7 @@ import org.scalatest.matchers.ShouldMatchers
 import com.google.inject._
 
 class BindingExtensionsSpec extends WordSpec with ShouldMatchers {
-  
+
   import BindingExtensions._
 
   def module(body: Binder => Unit) =  new Module {
@@ -29,7 +29,7 @@ class BindingExtensionsSpec extends WordSpec with ShouldMatchers {
   }
 
   "Binding extensions" should {
-  
+
     "allow binding source type using a type parameter" in {
       Guice createInjector module { binder =>
         binder.bindType[A].to(classOf[B])
@@ -48,27 +48,27 @@ class BindingExtensionsSpec extends WordSpec with ShouldMatchers {
       } getInstance(new Key[Gen[String]] {})
       inst.get should equal ("String")
     }
-    
+
     "allow binding between nested types" in {
       val inst = Guice createInjector module { binder =>
           binder.bindType[Outer.Gen[String]].toType[Outer.C]
       } getInstance(new Key[Outer.Gen[String]] {})
       inst.get should equal ("String")
     }
-    
-    "allow binding to provider using type parameter" in { 
+
+    "allow binding to provider using type parameter" in {
       val inst = Guice createInjector module { binder =>
           binder.bindType[Gen[String]].toProviderType[GenStringProvider]
       } getInstance(new Key[Gen[String]] {})
       inst.get should equal ("String")
     }
-    
-    "allow binding to provider of subtype using type parameter" in { 
+
+    "allow binding to provider of subtype using type parameter" in {
       val inst = Guice createInjector module { binder =>
           binder.bindType[Gen[String]].toProviderType[CProvider]
       } getInstance(new Key[Gen[String]] {})
       inst.get should equal ("String")
-    } 
+    }
 
   }
 

--- a/src/test/scala/net/codingwell/scalaguice/ClassesForTesting.scala
+++ b/src/test/scala/net/codingwell/scalaguice/ClassesForTesting.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package uk.me.lings.scalaguice
+package net.codingwell.scalaguice
 
 import com.google.inject.Inject
 import com.google.inject.Provider
@@ -54,6 +54,6 @@ class GenStringProvider extends Provider[Gen[String]] {
   def get = new C
 }
 
-class CProvider extends Provider[C] { 
+class CProvider extends Provider[C] {
   def get = new C
 }

--- a/src/test/scala/net/codingwell/scalaguice/InjectorExtensionsSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/InjectorExtensionsSpec.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package uk.me.lings.scalaguice
+package net.codingwell.scalaguice
 
 import org.scalatest.WordSpec
 import org.scalatest.matchers.ShouldMatchers
@@ -22,7 +22,7 @@ import com.google.inject._
 import com.google.inject.name.Names.named
 
 class InjectorExtensionsSpec extends WordSpec with ShouldMatchers {
-  
+
   import InjectorExtensions._
 
   val module = new AbstractModule {
@@ -36,7 +36,7 @@ class InjectorExtensionsSpec extends WordSpec with ShouldMatchers {
   val injector = Guice createInjector module
 
   "Injector extensions" should {
-  
+
     "allow instance to be retrieved using a type parameter" in {
       injector.instance[A]
     }

--- a/src/test/scala/net/codingwell/scalaguice/MultibinderSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/MultibinderSpec.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package uk.me.lings.scalaguice
+package net.codingwell.scalaguice
 
 import org.scalatest.WordSpec
 import org.scalatest.matchers.ShouldMatchers

--- a/src/test/scala/net/codingwell/scalaguice/ScalaModuleSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/ScalaModuleSpec.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package uk.me.lings.scalaguice
+package net.codingwell.scalaguice
 
 import org.scalatest.WordSpec
 import org.scalatest.matchers.ShouldMatchers

--- a/src/test/scala/net/codingwell/scalaguice/ScalaPrivateModuleSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/ScalaPrivateModuleSpec.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package uk.me.lings.scalaguice
+package net.codingwell.scalaguice
 
 import org.scalatest.WordSpec
 import org.scalatest.matchers.ShouldMatchers

--- a/src/test/scala/net/codingwell/scalaguice/SetProviderSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/SetProviderSpec.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package uk.me.lings.scalaguice
+package net.codingwell.scalaguice
 
 import org.scalatest.WordSpec
 import org.scalatest.matchers.ShouldMatchers

--- a/src/test/scala/net/codingwell/scalaguice/TypeLiteralSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/TypeLiteralSpec.scala
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package uk.me.lings.scalaguice
+package net.codingwell.scalaguice
 
 import org.scalatest.Spec
 import org.scalatest.matchers.ShouldMatchers
 
 class TypeLiteralSpec extends Spec with ShouldMatchers {
-  
+
   import com.google.inject._
 
   object Outer {
@@ -39,7 +39,7 @@ class TypeLiteralSpec extends Spec with ShouldMatchers {
     it("should convert type parameters to wrapper classes") {
       typeLiteral[List[Int]] should equal (new TypeLiteral[List[java.lang.Integer]] {})
     }
-    
+
     it("should handle nested types") {
       typeLiteral[Outer.Inner] should equal (TypeLiteral.get(classOf[Outer.Inner]))
     }
@@ -47,7 +47,7 @@ class TypeLiteralSpec extends Spec with ShouldMatchers {
     it("should handle type parameters that are nested types") {
       typeLiteral[List[Outer.Inner]] should equal (new TypeLiteral[List[Outer.Inner]] {})
     }
-    
+
     it("should handle type parameters that are arrays") {
       typeLiteral[Array[Int]] should equal (new TypeLiteral[Array[Int]] {})
     }


### PR DESCRIPTION
Rebranding the package names as well as moving to a proper file structure.
