### PR TITLE
Update Readme to use the pimp-my-library implicit conversion technique.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ Wrap the injector in a ScalaInjector for even more rich scala magic:
 ```scala
 object MyServer {
   def main(args: Array[String]) {
-    val injector = new ScalaInjector(Guice.createInjector(new MyModule(), new MyPrivateModule))
+    val injector = Guice.createInjector(new MyModule(), new MyPrivateModule)
 
+    import net.codingwell.scalaguice.ScalaExtensons._
     val service = injector.instance[Service]
     val foo = injector.instance[Foo]
     ...


### PR DESCRIPTION
Obviously this was the intended use pattern as all original methods on the Guice injector are not available. So, just updating documentation to reflect intentions.
