### PR TITLE
Transform README modules to objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ object MyPrivateModule extends PrivateModule with ScalaPrivateModule {
     bind[Foo].to[RealFoo]
     expose[Foo]
 
-    install(TransactionalBarModule())
+    install(TransactionalBarModule)
     expose[Bar].annotatedWith[Transactional]
 
     bind[SomeImplementationDetail]
-    install(MoreImplementationDetailsModule())
+    install(MoreImplementationDetailsModule)
   }
 }
 ```


### PR DESCRIPTION
Guice allows installing modules twice (or more) if they are equal.
If there is no reason why the module has to be a class and have many different instances, it's better to make it an object.

More 'bonus features': http://stackoverflow.com/questions/2716993/hidden-features-of-google-guice
