### PR TITLE
Create some Scala Magic in response to the new OptionalBinder.

### DIFF
--- a/src/main/scala/net/codingwell/scalaguice/OptionProvider.scala
+++ b/src/main/scala/net/codingwell/scalaguice/OptionProvider.scala
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 2010-2014 Benjamin Lings
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.codingwell.scalaguice
+
+import java.util
+
+import com.google.common.base.Optional
+import com.google.common.collect.ImmutableSet
+import com.google.inject.{Inject, Injector, Key}
+import com.google.inject.spi.{Dependency, ProviderWithDependencies}
+
+/**
+ * Provider for Scala's Option from Guava's Optional.
+ *
+ * Example:
+ * {{{
+ * .toProvider(new OptionProvider[T](Key.get(typeLiteral[Optional[T]])))
+ * }}}
+ */
+class OptionProvider[T] (source: Key[Optional[T]]) extends ProviderWithDependencies[Option[T]] {
+  @Inject() private[this] val injector: Injector = null
+
+  override def get(): Option[T] = {
+    val opt = injector.getInstance(source)
+    if (opt.isPresent) Some(opt.get) else None
+  }
+
+  override def getDependencies: util.Set[Dependency[_]] = {
+    ImmutableSet.of(Dependency.get(source))
+  }
+}

--- a/src/main/scala/net/codingwell/scalaguice/ScalaOptionBinder.scala
+++ b/src/main/scala/net/codingwell/scalaguice/ScalaOptionBinder.scala
@@ -1,0 +1,182 @@
+/*
+ *  Copyright 2010-2014 Benjamin Lings
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.codingwell.scalaguice
+
+import java.lang.annotation.Annotation
+
+import com.google.common.base.Optional
+import com.google.inject.multibindings.OptionalBinder
+import com.google.inject.{Binder, Key, Module, Provider, TypeLiteral}
+import net.codingwell.scalaguice.ScalaModule.ScalaLinkedBindingBuilder
+
+/**
+ * Analog to Guice's OptionalBinder
+ *
+ * Use [[ScalaOptionBinder.newOptionBinder]] to create an option binder that is scala friendly.
+ */
+trait ScalaOptionBinder[T] {
+  /**
+   * Returns a binding builder used to set the default value that will be injected.
+   * The binding set by this method will be ignored if `setBinding` is called.
+   *
+   * <p>It is an error to call this method without also calling one of the `to`
+   * methods on the returned binding builder.
+   */
+  def setDefault: ScalaLinkedBindingBuilder[T]
+
+  /**
+   * Returns a binding builder used to set the actual value that will be injected.
+   * This overrides any binding set by `setDefault`.
+   *
+   * <p>It is an error to call this method without also calling one of the `to`
+   * methods on the returned binding builder.
+   */
+  def setBinding: ScalaLinkedBindingBuilder[T]
+}
+
+object ScalaOptionBinder {
+  /** Preferred Scala Methods */
+
+  /**
+   * Returns a new optionbinder that binds an instance of [[T]] in a [[scala.Option]].
+   */
+  def newOptionBinder[T: Manifest](binder: Binder): ScalaOptionBinder[T] = {
+    newOptionBinder(binder, typeLiteral[T])
+  }
+
+  /**
+   * Returns a new optionbinder that binds an instance of [[T]] in a [[scala.Option]] that is
+   * itself bound with a binding annotation [[Ann]].
+   */
+  def newOptionBinder[T: Manifest, Ann <: Annotation : Manifest](binder: Binder): ScalaOptionBinder[T] = {
+    newOptionBinder(binder, Key.get(typeLiteral[T], cls[Ann]))
+  }
+
+  /**
+   * Returns a new optionbinder that binds an instance of [[T]] in a [[scala.Option]] that is
+   * itself bound with a binding annotation.
+   */
+  def newOptionBinder[T: Manifest](binder: Binder, annotation: Annotation): ScalaOptionBinder[T] = {
+    newOptionBinder(binder, Key.get(typeLiteral[T], annotation))
+  }
+
+  /**
+   * Returns a new optionbinder that binds `typ` in a [[scala.Option]]. Note that
+   * `typ` is ignored in favor of using the Manifest to capture type arguments.
+   */
+  def newOptionBinder[T: Manifest](binder: Binder, typ: Class[T]): ScalaOptionBinder[T] = {
+    newOptionBinder(binder, typeLiteral[T])
+  }
+
+  /**
+   * Returns a new optionbinder that binds an instance of the type represented by `typeLiteral` in a [[scala.Option]].
+   */
+  def newOptionBinder[T](binder: Binder, typeLiteral: TypeLiteral[T]): ScalaOptionBinder[T] = {
+    newOptionBinder(binder, Key.get(typeLiteral))
+  }
+
+  /**
+   * Returns a new optionbinder that binds an instance of the type represented by `key` in a [[scala.Option]]. It may or
+   * may not be bound with a binding annotation (depending on the key).
+   */
+  def newOptionBinder[T](parentBinder: Binder, key: Key[T]): ScalaOptionBinder[T] = {
+    val binder = parentBinder.skipSources(
+      ScalaOptionBinder.getClass,
+      classOf[ScalaOptionBinder[T]],
+      classOf[RealScalaOptionBinder[T]]
+    )
+    val jOptionalBinder = OptionalBinder.newOptionalBinder(binder, key)
+    val result = new RealScalaOptionBinder[T](jOptionalBinder, key)
+    binder.install(result)
+    result
+  }
+
+  /** Guice's Optional Binder API */
+
+  /**
+   * Returns a new optionbinder that binds `typ` in a [[scala.Option]]. Note that
+   * `typ` is ignored in favor of using the Manifest to capture type arguments.
+   */
+  def newOptionalBinder[T: Manifest](binder: Binder, typ: Class[T]): ScalaOptionBinder[T] = {
+    newOptionBinder(binder, typ)
+  }
+
+  /**
+   * Returns a new optionbinder that binds an instance of the type represented by `typeLiteral` in a [[scala.Option]].
+   */
+  def newOptionalBinder[T](binder: Binder, typeLiteral: TypeLiteral[T]): ScalaOptionBinder[T] = {
+    newOptionBinder(binder, typeLiteral)
+  }
+
+  /**
+   * Returns a new optionbinder that binds an instance of the type represented by `key` in a [[scala.Option]]. It may or
+   * may not be bound with a binding annotation (depending on the key).
+   */
+  def newOptionalBinder[T](parentBinder: Binder, key: Key[T]): ScalaOptionBinder[T] = {
+    newOptionBinder(parentBinder, key)
+  }
+
+  /**
+   * Analog to the Guice's [[com.google.inject.multibindings.OptionalBinder.RealOptionalBinder]]
+   *
+   * As a Module, the [[RealScalaOptionBinder]] installs the binding to the option itself. As a module, this implements
+   * `equals()` and `hashCode()` in order to trick Guice into executing its `configure` method only once. That makes
+   * it so that multiple binders can be created for the same target option, but only one is bound. The binding maps
+   * the [[com.google.common.base.Optional]] to a [[scala.Option]] for useful Scala injection.
+   */
+  private class RealScalaOptionBinder[T](parent: OptionalBinder[T], key: Key[T]) extends ScalaOptionBinder[T] with Module {
+    private[this] val optName = nameOf(key)
+    private val optKey = key.ofType(wrap[Option].around(key.getTypeLiteral))
+
+    def setDefault: ScalaLinkedBindingBuilder[T] = new ScalaLinkedBindingBuilder[T] {
+      val self = parent.setDefault()
+    }
+
+    def setBinding: ScalaLinkedBindingBuilder[T] = new ScalaLinkedBindingBuilder[T] {
+      val self = parent.setBinding()
+    }
+
+    def getJavaOptionalBinder: OptionalBinder[T] = {
+      parent
+    }
+
+    def configure(binder: Binder) {
+      bindMapping(binder, key.getTypeLiteral)
+      bindMapping(binder, wrap[Provider].around(key.getTypeLiteral))
+      bindMapping(binder, wrap[javax.inject.Provider].around(key.getTypeLiteral))
+    }
+
+    private[this] def bindMapping[S](binder: Binder, typ: TypeLiteral[S]): Unit = {
+      val sKey = key.ofType(wrap[Option].around(typ))
+      val jKey = key.ofType(wrap[Optional].around(typ))
+      binder.bind(sKey).toProvider(new OptionProvider(jKey))
+    }
+
+    /** Trick Guice into installing this Module once. */
+    override def equals(o: Any): Boolean = o match {
+      case o: RealScalaOptionBinder[_] => o.optKey == optKey
+      case _ => false
+    }
+
+    override def hashCode: Int = {
+      optKey.hashCode
+    }
+
+    override def toString: String = {
+      (if (optName.isEmpty) "" else optName + " ") + "ScalaOptionBinder<" + key.getTypeLiteral + ">"
+    }
+  }
+}

--- a/src/test/scala/net/codingwell/scalaguice/OptionProviderSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/OptionProviderSpec.scala
@@ -1,0 +1,50 @@
+/*
+ *  Copyright 2010-2014 Benjamin Lings
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.codingwell.scalaguice
+
+import com.google.common.base.Optional
+import com.google.inject.name.Named
+import com.google.inject.{AbstractModule, Guice, Key}
+import net.codingwell.scalaguice.InjectorExtensions._
+import org.scalatest.{Matchers, WordSpec}
+
+class OptionProviderSpec extends WordSpec with Matchers {
+  "An Option Provider" should {
+    "allow binding an Optional" in {
+      val module = new AbstractModule with ScalaModule {
+        def configure(): Unit = {
+          bind[Optional[String]].toInstance(Optional.of("Hello World"))
+          val key = Key.get(typeLiteral[Optional[String]])
+          bind[Option[String]].toProvider(new OptionProvider[String](key))
+        }
+      }
+      val opt = Guice.createInjector(module).instance[Option[String]]
+      opt should contain("Hello World")
+    }
+  }
+
+  "allow binding an Optional with an annotation" in {
+    val module = new AbstractModule with ScalaModule {
+      def configure(): Unit = {
+        bind[Optional[String]].annotatedWith[Named].toInstance(Optional.of("Hello World"))
+        val key = Key.get(typeLiteral[Optional[String]], classOf[Named])
+        bind[Option[String]].annotatedWith[Named].toProvider(new OptionProvider(key))
+      }
+    }
+    val opt = Guice.createInjector(module).instance[Option[String], Named]
+    opt should contain("Hello World")
+  }
+}

--- a/src/test/scala/net/codingwell/scalaguice/ScalaOptionBinderSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/ScalaOptionBinderSpec.scala
@@ -1,0 +1,345 @@
+/*
+ *  Copyright 2010-2014 Benjamin Lings
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.codingwell.scalaguice
+
+import java.lang.annotation.Annotation
+
+import com.google.common.base.Optional
+import com.google.inject.name.{Named, Names}
+import com.google.inject.{AbstractModule, Guice, Key, Module, Provider}
+import net.codingwell.scalaguice.InjectorExtensions._
+import org.scalatest.{Matchers, WordSpec}
+
+class ScalaOptionBinderSpec extends WordSpec with Matchers {
+  private case class W[T](t: T)
+  private val annotation = Names.named("N")
+
+  "An OptionBinder" should {
+    /** New Scala Methods, Happy Path */
+
+    "bind [T]" in {
+      val module = new AbstractModule {
+        override def configure(): Unit = {
+          val opt = ScalaOptionBinder.newOptionBinder[String](binder)
+          opt.setDefault.toInstance("A")
+        }
+      }
+
+      validate(module)
+    }
+
+    "bind [T, Ann]" in {
+      val module = new AbstractModule {
+        override def configure(): Unit = {
+          val opt = ScalaOptionBinder.newOptionBinder[String, Named](binder)
+          opt.setDefault.toInstance("A")
+        }
+      }
+
+      validateWithAnn[String, Named](module)
+    }
+
+    "bind [T, Annotation]" in {
+      val module = new AbstractModule {
+        override def configure(): Unit = {
+          val opt = ScalaOptionBinder.newOptionBinder[String](binder, annotation)
+          opt.setDefault.toInstance("A")
+        }
+      }
+
+      validateWithAnnotation(module, annotation)
+    }
+
+    "bind [Class]" in {
+      val module = new AbstractModule {
+        override def configure(): Unit = {
+          val opt = ScalaOptionBinder.newOptionBinder(binder, classOf[String])
+          opt.setDefault.toInstance("A")
+        }
+      }
+
+      validate(module)
+    }
+
+    "bind [TypeLiteral]" in {
+      val module = new AbstractModule {
+        override def configure(): Unit = {
+          val opt = ScalaOptionBinder.newOptionBinder(binder, typeLiteral[String])
+          opt.setDefault.toInstance("A")
+        }
+      }
+
+      validate(module)
+    }
+
+    "bind [Key]" in {
+      val module = new AbstractModule {
+        override def configure(): Unit = {
+          val opt = ScalaOptionBinder.newOptionBinder(binder, Key.get(typeLiteral[String]))
+          opt.setDefault.toInstance("A")
+        }
+      }
+
+      validate(module)
+    }
+
+    /** Guice's Optional Binder API, Happy Path */
+    "bind optional (original API) [Class]" in {
+      val module = new AbstractModule {
+        override def configure(): Unit = {
+          val opt = ScalaOptionBinder.newOptionalBinder(binder, classOf[String])
+          opt.setDefault.toInstance("A")
+        }
+      }
+
+      validate(module)
+    }
+
+    "bind optional (original API) [TypeLiteral]" in {
+      val module = new AbstractModule {
+        override def configure(): Unit = {
+          val opt = ScalaOptionBinder.newOptionalBinder(binder, typeLiteral[String])
+          opt.setDefault.toInstance("A")
+        }
+      }
+
+      validate(module)
+    }
+
+    "bind optional (original API) [Key]" in {
+      val module = new AbstractModule {
+        override def configure(): Unit = {
+          val opt = ScalaOptionBinder.newOptionalBinder(binder, Key.get(typeLiteral[String]))
+          opt.setDefault.toInstance("A")
+        }
+      }
+
+      validate(module)
+    }
+
+    /** Non Happy Path */
+    "override default value" in {
+      val module = new AbstractModule {
+        override def configure(): Unit = {
+          val opt = ScalaOptionBinder.newOptionBinder[String](binder)
+          opt.setDefault.toInstance("B")
+          opt.setBinding.toInstance("A")
+        }
+      }
+
+      validate(module)
+    }
+
+    "override default value with second binder" in {
+      val module = new AbstractModule {
+        override def configure(): Unit = {
+          val opt = ScalaOptionBinder.newOptionBinder[String](binder)
+          opt.setDefault.toInstance("B")
+          val opt2 = ScalaOptionBinder.newOptionBinder[String](binder)
+          opt2.setBinding.toInstance("A")
+        }
+      }
+
+      validate(module)
+    }
+
+    "allow separately annotated bindings for the same [T]" in {
+      val module = new AbstractModule {
+        override def configure(): Unit = {
+          val aOpt = ScalaOptionBinder.newOptionBinder[String](binder, Names.named("A"))
+          aOpt.setBinding.toInstance("A")
+          val bOpt = ScalaOptionBinder.newOptionBinder[String](binder, Names.named("B"))
+          bOpt.setDefault.toInstance("B")
+        }
+      }
+
+      validateWithAnnotation(module, Names.named("A"), expected = "A")
+      validateWithAnnotation(module, Names.named("B"), expected = "B")
+    }
+
+    /** New Scala Methods, Parameterized Wrappers */
+
+    "bind deep parameterization [T]" in {
+      val module = new AbstractModule {
+        override def configure(): Unit = {
+          val sOpt = ScalaOptionBinder.newOptionBinder[W[String]](binder)
+          sOpt.setDefault.toInstance(W("A"))
+          val nOpt = ScalaOptionBinder.newOptionBinder[W[Int]](binder)
+          nOpt.setDefault.toInstance(W(1))
+        }
+      }
+
+      validate(module, expected = W("A"))
+      validate(module, expected = W(1))
+    }
+
+    "bind deep parameterization in [T, Ann]" in {
+      val module = new AbstractModule {
+        override def configure(): Unit = {
+          val sOpt = ScalaOptionBinder.newOptionBinder[W[String], Named](binder)
+          sOpt.setDefault.toInstance(W("A"))
+          val nOpt = ScalaOptionBinder.newOptionBinder[W[Int], Named](binder)
+          nOpt.setDefault.toInstance(W(1))
+        }
+      }
+
+      validateWithAnn[W[String], Named](module, expected = W("A"))
+      validateWithAnn[W[Int], Named](module, expected = W(1))
+    }
+
+    "bind deep parameterization in [T, Annotation]" in {
+      val module = new AbstractModule {
+        override def configure(): Unit = {
+          val sOpt = ScalaOptionBinder.newOptionBinder[W[String]](binder, annotation)
+          sOpt.setDefault.toInstance(W("A"))
+          val nOpt = ScalaOptionBinder.newOptionBinder[W[Int]](binder, annotation)
+          nOpt.setDefault.toInstance(W(1))
+        }
+      }
+
+      validateWithAnnotation(module, annotation, expected = W("A"))
+      validateWithAnnotation(module, annotation, expected = W(1))
+    }
+
+    "bind deep parameterization in [Class]" in {
+      val module = new AbstractModule {
+        override def configure(): Unit = {
+          val sOpt = ScalaOptionBinder.newOptionBinder(binder, classOf[W[String]])
+          sOpt.setBinding.toInstance(W("A"))
+          val nOpt = ScalaOptionBinder.newOptionBinder(binder, classOf[W[Int]])
+          nOpt.setDefault.toInstance(W(1))
+        }
+      }
+
+      validate(module, expected = W("A"))
+      validate(module, expected = W(1))
+    }
+
+    "bind deep parameterization in [TypeLiteral]" in {
+      val module = new AbstractModule {
+        override def configure(): Unit = {
+          val sOpt = ScalaOptionBinder.newOptionBinder(binder, typeLiteral[W[String]])
+          sOpt.setDefault.toInstance(W("A"))
+          val nOpt = ScalaOptionBinder.newOptionBinder(binder, typeLiteral[W[Int]])
+          nOpt.setDefault.toInstance(W(1))
+        }
+      }
+
+      validate(module, expected = W("A"))
+      validate(module, expected = W(1))
+    }
+
+    "bind deep parameterization in [Key]" in {
+      val module = new AbstractModule {
+        override def configure(): Unit = {
+          val sOpt = ScalaOptionBinder.newOptionBinder(binder, Key.get(typeLiteral[W[String]]))
+          sOpt.setDefault.toInstance(W("A"))
+          val nOpt = ScalaOptionBinder.newOptionBinder(binder, Key.get(typeLiteral[W[Int]]))
+          nOpt.setDefault.toInstance(W(1))
+        }
+      }
+
+      validate(module, expected = W("A"))
+      validate(module, expected = W(1))
+    }
+
+    /** Guice's Optional Binder API, Parameterized Wrappers */
+
+    "bind optional (original API) deep parameterization in [Class]" in {
+      val module = new AbstractModule {
+        override def configure(): Unit = {
+          val sOpt = ScalaOptionBinder.newOptionalBinder(binder, classOf[W[String]])
+          sOpt.setDefault.toInstance(W("A"))
+          val nOpt = ScalaOptionBinder.newOptionalBinder(binder, classOf[W[Int]])
+          nOpt.setDefault.toInstance(W(1))
+        }
+      }
+
+      validate(module, expected = W("A"))
+      validate(module, expected = W(1))
+    }
+
+    "bind optional (original API) deep parameterization in [TypeLiteral]" in {
+      val module = new AbstractModule {
+        override def configure(): Unit = {
+          val sOpt = ScalaOptionBinder.newOptionalBinder(binder, typeLiteral[W[String]])
+          sOpt.setDefault.toInstance(W("A"))
+          val nOpt = ScalaOptionBinder.newOptionalBinder(binder, typeLiteral[W[Int]])
+          nOpt.setDefault.toInstance(W(1))
+        }
+      }
+
+      validate(module, expected = W("A"))
+      validate(module, expected = W(1))
+    }
+
+    "bind optional (original API) deep parameterization in [Key]" in {
+      val module = new AbstractModule {
+        override def configure(): Unit = {
+          val sOpt = ScalaOptionBinder.newOptionalBinder(binder, Key.get(typeLiteral[W[String]]))
+          sOpt.setDefault.toInstance(W("A"))
+          val nOpt = ScalaOptionBinder.newOptionalBinder(binder, Key.get(typeLiteral[W[Int]]))
+          nOpt.setDefault.toInstance(W(1))
+        }
+      }
+
+      validate(module, expected = W("A"))
+      validate(module, expected = W(1))
+    }
+  }
+
+  private def validate[T: Manifest](module: Module, expected: T = "A"): Unit = {
+    val injector = Guice.createInjector(module)
+
+    // Check Option
+    injector.instance[Option[T]] should contain(expected)
+    injector.instance[Option[Provider[T]]].get.get() should equal(expected)
+    injector.instance[Option[javax.inject.Provider[T]]].get.get() should equal(expected)
+
+    // Check Optional
+    injector.instance[Optional[T]].get should equal(expected)
+    injector.instance[Optional[Provider[T]]].get.get() should equal(expected)
+    injector.instance[Optional[javax.inject.Provider[T]]].get.get() should equal(expected)
+  }
+
+  private def validateWithAnn[T: Manifest, Ann <: Annotation : Manifest](module: Module, expected: T = "A"): Unit = {
+    val injector = Guice.createInjector(module)
+
+    // Check Option
+    injector.instance[Option[T], Ann] should contain(expected)
+    injector.instance[Option[Provider[T]], Ann].get.get() should equal(expected)
+    injector.instance[Option[javax.inject.Provider[T]], Ann].get.get() should equal(expected)
+
+    // Check Optional
+    injector.instance[Optional[T], Ann].get should equal(expected)
+    injector.instance[Optional[Provider[T]], Ann].get.get() should equal(expected)
+    injector.instance[Optional[javax.inject.Provider[T]], Ann].get.get() should equal(expected)
+  }
+
+  private def validateWithAnnotation[T: Manifest](module: Module, annotation: Annotation, expected: T = "A"): Unit = {
+    val injector = Guice.createInjector(module)
+
+    // Check Option
+    injector.instance[Option[T]](annotation) should contain(expected)
+    injector.instance[Option[Provider[T]]](annotation).get.get() should equal(expected)
+    injector.instance[Option[javax.inject.Provider[T]]](annotation).get.get() should equal(expected)
+
+    // Check Optional
+    injector.instance[Optional[T]](annotation).get should equal(expected)
+    injector.instance[Optional[Provider[T]]](annotation).get.get() should equal(expected)
+    injector.instance[Optional[javax.inject.Provider[T]]](annotation).get.get() should equal(expected)
+  }
+}


### PR DESCRIPTION
This fixes #22.

In particular, I added all of the necessary scala magic to be able to ask for Option[T], Option[Provider[T]] and Option[javax.inject.Provider[T]] instead of the Guava Optional equivalents. This is solved similarly to how ScalaMultibinder is implemented. The readme is updated as well.

This pull request only shares a single commit from the other commit, specifically 2145abf (adding new injector extension methods).
