### PR TITLE
Provide optional access to existing bindings on Injector

### DIFF
--- a/src/main/scala/net/codingwell/scalaguice/InjectorExtensions.scala
+++ b/src/main/scala/net/codingwell/scalaguice/InjectorExtensions.scala
@@ -27,5 +27,7 @@ object InjectorExtensions {
     def instance[T: Manifest, Ann <: Annotation : Manifest] = i.getInstance(typeLiteral[T].annotatedWith[Ann])
 
     def existingBinding[T: Manifest] = Option(i.getExistingBinding(typeLiteral[T].toKey))
+    def existingBinding[T: Manifest](ann: Annotation) = Option(i.getExistingBinding(typeLiteral[T].annotatedWith(ann)))
+    def existingBinding[T: Manifest, Ann <: Annotation : Manifest] = Option(i.getExistingBinding(typeLiteral[T].annotatedWith[Ann]))
   }
 }

--- a/src/main/scala/net/codingwell/scalaguice/InjectorExtensions.scala
+++ b/src/main/scala/net/codingwell/scalaguice/InjectorExtensions.scala
@@ -15,7 +15,7 @@
  */
 package net.codingwell.scalaguice
 
-import com.google.inject.Injector
+import com.google.inject.{Key, Injector}
 import java.lang.annotation.Annotation
 import KeyExtensions._
 
@@ -25,5 +25,7 @@ object InjectorExtensions {
     def instance[T: Manifest] = i.getInstance(typeLiteral[T].toKey)
     def instance[T: Manifest](ann: Annotation) = i.getInstance(typeLiteral[T].annotatedWith(ann))
     def instance[T: Manifest, Ann <: Annotation : Manifest] = i.getInstance(typeLiteral[T].annotatedWith[Ann])
+
+    def existingBinding[T: Manifest] = Option(i.getExistingBinding(typeLiteral[T].toKey))
   }
 }

--- a/src/test/scala/net/codingwell/scalaguice/InjectorExtensionsSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/InjectorExtensionsSpec.scala
@@ -56,7 +56,7 @@ class InjectorExtensionsSpec extends WordSpec with Matchers {
 
     "allow existing bindings to be retrieved optionally" in {
       val Some(binding) = injector.existingBinding[A]
-      binding.getKey.getTypeLiteral == typeLiteral[B]
+      binding.getProvider.get() shouldBe a [B]
     }
 
     "allow missing bindings to be retrieved optionally" in {

--- a/src/test/scala/net/codingwell/scalaguice/InjectorExtensionsSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/InjectorExtensionsSpec.scala
@@ -53,5 +53,14 @@ class InjectorExtensionsSpec extends WordSpec with Matchers {
     "allow instance to be retreived using a type parameter and an annotation class" in {
       injector.instance[B, Named]
     }
+
+    "allow existing bindings to be retrieved optionally" in {
+      val Some(binding) = injector.existingBinding[A]
+      binding.getKey.getTypeLiteral == typeLiteral[B]
+    }
+
+    "allow missing bindings to be retrieved optionally" in {
+      injector.existingBinding[Foo] should not be defined
+    }
   }
 }

--- a/src/test/scala/net/codingwell/scalaguice/InjectorExtensionsSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/InjectorExtensionsSpec.scala
@@ -62,5 +62,24 @@ class InjectorExtensionsSpec extends WordSpec with Matchers {
     "allow missing bindings to be retrieved optionally" in {
       injector.existingBinding[Foo] should not be defined
     }
+
+    "allow existing annotated bindings to be retrieved optionally" in {
+      val Some(binding) = injector.existingBinding[B, Named]
+      binding.getProvider.get() shouldBe a [B]
+    }
+
+    "allow missing annotated bindings to be retrieved optionally" in {
+      injector.existingBinding[Foo, Named] should not be defined
+    }
+
+    "allow existing named bindings to be retrieved optionally" in {
+      val Some(binding) = injector.existingBinding[A](named("d"))
+      binding.getProvider.get() shouldBe a [B]
+    }
+
+    "allow missing named bindings to be retrieved optionally" in {
+      injector.existingBinding[Foo](named("d")) should not be defined
+      injector.existingBinding[A](named("foo")) should not be defined
+    }
   }
 }


### PR DESCRIPTION
Please consider this change which adds optional access to existing bindings on an Injector.
