### PR TITLE
Replace uses of Manifest with ClassTag / TypeTag

### DIFF
--- a/src/main/scala/net/codingwell/package.scala
+++ b/src/main/scala/net/codingwell/package.scala
@@ -29,7 +29,7 @@ import scala.reflect.runtime.universe.{TypeTag, typeOf}
 package object scalaguice {
 
   /**
-   * Create a com.google.inject.TypeLiteral from a [[scala.reflect.Manifest]].
+   * Create a [[com.google.inject.TypeLiteral]] from a [[scala.reflect.runtime.universe.TypeTag]].
    * Subtypes of [[scala.AnyVal]] will be converted to their corresponding
    * Java wrapper classes.
    */

--- a/src/main/scala/net/codingwell/scalaguice/BindingExtensions.scala
+++ b/src/main/scala/net/codingwell/scalaguice/BindingExtensions.scala
@@ -19,6 +19,7 @@ import com.google.inject.Binder
 import com.google.inject.binder._
 import com.google.inject.name.Names
 import java.lang.annotation.{Annotation => JAnnotation}
+import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 
 import javax.inject.Provider
@@ -50,26 +51,26 @@ object BindingExtensions {
   }
 
   implicit class ScalaScopedBindingBuilder(b: ScopedBindingBuilder) {
-    def inType[TAnn <: JAnnotation : Manifest]() = b in cls[TAnn]
+    def inType[TAnn <: JAnnotation : ClassTag]() = b in cls[TAnn]
   }
 
   implicit class ScalaLinkedBindingBuilder[T](b: LinkedBindingBuilder[T]) {
     def toType[TImpl <: T : TypeTag] = b to typeLiteral[TImpl]
 
-    def toProviderType[TProvider <: Provider[_ <: T] : Manifest] = b toProvider cls[TProvider]
+    def toProviderType[TProvider <: Provider[_ <: T] : ClassTag] = b toProvider cls[TProvider]
   }
 
   implicit class ScalaAnnotatedBindingBuilder[T](b: AnnotatedBindingBuilder[T]) {
-    def annotatedWithType[TAnn <: JAnnotation : Manifest] = b annotatedWith cls[TAnn]
+    def annotatedWithType[TAnn <: JAnnotation : ClassTag] = b annotatedWith cls[TAnn]
   }
 
   implicit class ScalaAnnotatedConstantBindingBuilder(b: AnnotatedConstantBindingBuilder) {
-    def annotatedWithType[TAnn <: JAnnotation : Manifest] = b annotatedWith cls[TAnn]
+    def annotatedWithType[TAnn <: JAnnotation : ClassTag] = b annotatedWith cls[TAnn]
     def annotatedWithName(name: String) = b annotatedWith Names.named(name)
   }
 
   implicit class ScalaConstantBindingBuilder(b: ConstantBindingBuilder) {
-    def to[T: Manifest]() = b to cls[T]
+    def to[T: ClassTag]() = b to cls[T]
   }
 }
 

--- a/src/main/scala/net/codingwell/scalaguice/InjectorExtensions.scala
+++ b/src/main/scala/net/codingwell/scalaguice/InjectorExtensions.scala
@@ -18,6 +18,7 @@ package net.codingwell.scalaguice
 import com.google.inject.{Binding, Key, Injector}
 import java.lang.annotation.Annotation
 import KeyExtensions._
+import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
 
 object InjectorExtensions {
@@ -25,11 +26,11 @@ object InjectorExtensions {
   implicit class ScalaInjector(i: Injector) {
     def instance[T: TypeTag] = i.getInstance(typeLiteral[T].toKey)
     def instance[T: TypeTag](ann: Annotation) = i.getInstance(typeLiteral[T].annotatedWith(ann))
-    def instance[T: TypeTag, Ann <: Annotation : Manifest] = i.getInstance(typeLiteral[T].annotatedWith[Ann])
+    def instance[T: TypeTag, Ann <: Annotation : ClassTag] = i.getInstance(typeLiteral[T].annotatedWith[Ann])
 
     def existingBinding[T: TypeTag]: Option[Binding[T]] = existingBinding(typeLiteral[T].toKey)
     def existingBinding[T: TypeTag](ann: Annotation): Option[Binding[T]] = existingBinding(typeLiteral[T].annotatedWith(ann))
-    def existingBinding[T: TypeTag, Ann <: Annotation : Manifest]: Option[Binding[T]] = existingBinding(typeLiteral[T].annotatedWith[Ann])
+    def existingBinding[T: TypeTag, Ann <: Annotation : ClassTag]: Option[Binding[T]] = existingBinding(typeLiteral[T].annotatedWith[Ann])
     def existingBinding[T](key: Key[T]): Option[Binding[T]] = Option(i.getExistingBinding(key))
   }
 }

--- a/src/main/scala/net/codingwell/scalaguice/KeyExtensions.scala
+++ b/src/main/scala/net/codingwell/scalaguice/KeyExtensions.scala
@@ -18,13 +18,14 @@ package net.codingwell.scalaguice
 import com.google.inject._
 import java.lang.annotation.{Annotation => JAnnotation}
 import com.google.inject.name.Names
+import scala.reflect.ClassTag
 
 object KeyExtensions {
 
   implicit class ScalaTypeLiteral[T](t: TypeLiteral[T]) {
     def toKey: Key[T] = Key.get(t)
     def annotatedWith(annotation: JAnnotation): Key[T] = Key.get(t, annotation)
-    def annotatedWith[TAnn <: JAnnotation : Manifest]: Key[T] = Key.get(t, cls[TAnn])
+    def annotatedWith[TAnn <: JAnnotation : ClassTag]: Key[T] = Key.get(t, cls[TAnn])
     def annotatedWithName(name: String) = annotatedWith(Names.named(name))
   }
 }

--- a/src/main/scala/net/codingwell/scalaguice/ScalaMultibinder.scala
+++ b/src/main/scala/net/codingwell/scalaguice/ScalaMultibinder.scala
@@ -24,6 +24,8 @@ import com.google.inject.{Binder, Key, Module, TypeLiteral}
 import net.codingwell.scalaguice.ScalaModule.ScalaLinkedBindingBuilder
 
 import scala.collection.{immutable => im}
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe.TypeTag
 
 /**
  * Analog to Guice's Multibinder
@@ -62,7 +64,7 @@ object ScalaMultibinder {
    * Returns a new multibinder that collects instances of type `T` in a [[scala.collection.immutable.Set]] that is
    * itself bound with no binding annotation.
    */
-  def newSetBinder[T: Manifest](binder: Binder) = {
+  def newSetBinder[T: TypeTag](binder: Binder) = {
     newMultibinder(binder, typeLiteral[T])
   }
 
@@ -70,7 +72,7 @@ object ScalaMultibinder {
    * Returns a new multibinder that collects instances of type `T` in a [[scala.collection.immutable.Set]] that is
    * itself bound with a binding annotation `Ann`.
    */
-  def newSetBinder[T: Manifest, Ann <: Annotation : Manifest](binder: Binder) = {
+  def newSetBinder[T: TypeTag, Ann <: Annotation : ClassTag](binder: Binder) = {
     newMultibinder[T, Ann](binder, typeLiteral[T], cls[Ann])
   }
 
@@ -78,7 +80,7 @@ object ScalaMultibinder {
    * Returns a new multibinder that collects instances of type `T` in a [[scala.collection.immutable.Set]] that is
    * itself bound with a binding annotation.
    */
-  def newSetBinder[T: Manifest](binder: Binder, annotation: Annotation) = {
+  def newSetBinder[T: TypeTag](binder: Binder, annotation: Annotation) = {
     newMultibinder(binder, typeLiteral[T], annotation)
   }
 
@@ -94,10 +96,10 @@ object ScalaMultibinder {
 
   /**
    * Returns a new multibinder that collects instances of `typ` in a [[scala.collection.immutable.Set]] that is
-   * itself bound with no binding annotation. Note that `typ` is ignored in favor of using the `T` Manifest to capture
+   * itself bound with no binding annotation. Note that `typ` is ignored in favor of using the `T` TypeTag to capture
    * type arguments.
    */
-  def newSetBinder[T: Manifest](binder: Binder, typ: Class[T]) = {
+  def newSetBinder[T: TypeTag](binder: Binder, typ: Class[T]) = {
     newMultibinder(binder, typeLiteral[T])
   }
 
@@ -105,16 +107,16 @@ object ScalaMultibinder {
    * Returns a new multibinder that collects instances of `typ` in a [[scala.collection.immutable.Set]] that is
    * itself bound with a binding annotation.
    */
-  def newSetBinder[T: Manifest](binder: Binder, typ: TypeLiteral[T], annotation: Annotation) = {
+  def newSetBinder[T: TypeTag](binder: Binder, typ: TypeLiteral[T], annotation: Annotation) = {
     newMultibinder(binder, typ, annotation)
   }
 
   /**
    * Returns a new multibinder that collects instances of `typ` in a [[scala.collection.immutable.Set]] that is
-   * itself bound with a binding annotation. Note that `typ` is ignored in favor of using the Manifest to capture
+   * itself bound with a binding annotation. Note that `typ` is ignored in favor of using the TypeTag to capture
    * type arguments.
    */
-  def newSetBinder[T: Manifest](binder: Binder, typ: Class[T], annotation: Annotation) = {
+  def newSetBinder[T: TypeTag](binder: Binder, typ: Class[T], annotation: Annotation) = {
     newMultibinder(binder, typeLiteral[T], annotation)
   }
 
@@ -128,10 +130,10 @@ object ScalaMultibinder {
 
   /**
    * Returns a new multibinder that collects instances of `typ` in a [[scala.collection.immutable.Set]] that is
-   * itself bound with a binding annotation. Note that `typ` is ignored in favor of using the Manifest to capture
+   * itself bound with a binding annotation. Note that `typ` is ignored in favor of using the TypeTag to capture
    * type arguments.
    */
-  def newSetBinder[T: Manifest](binder: Binder, typ: Class[T], annotation: Class[_ <: Annotation]) = {
+  def newSetBinder[T: TypeTag](binder: Binder, typ: Class[T], annotation: Class[_ <: Annotation]) = {
     newMultibinder(binder, typeLiteral[T], annotation)
   }
 

--- a/src/test/scala/net/codingwell/scalaguice/InjectorExtensionsSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/InjectorExtensionsSpec.scala
@@ -21,6 +21,7 @@ import com.google.inject.{AbstractModule, Guice}
 import net.codingwell.scalaguice.InjectorExtensions._
 import net.codingwell.scalaguice.KeyExtensions._
 import org.scalatest.{Matchers, WordSpec}
+import scala.reflect.runtime.universe.TypeTag
 
 class InjectorExtensionsSpec extends WordSpec with Matchers {
 
@@ -83,8 +84,8 @@ class InjectorExtensionsSpec extends WordSpec with Matchers {
       injector.existingBinding[A](named("foo")) should not be defined
     }
 
-    def keyExistsFn[T: Manifest] = typeLiteral[T].toKey
-    def keyMissingFn[T: Manifest] = typeLiteral[T].annotatedWithName("foo")
+    def keyExistsFn[T: TypeTag] = typeLiteral[T].toKey
+    def keyMissingFn[T: TypeTag] = typeLiteral[T].annotatedWithName("foo")
 
     "allow existing bindings to be retrieved by key optionally" in {
       val Some(binding) = injector.existingBinding[A](keyExistsFn[A])

--- a/src/test/scala/net/codingwell/scalaguice/ScalaMapBinderSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/ScalaMapBinderSpec.scala
@@ -23,6 +23,8 @@ import net.codingwell.scalaguice.InjectorExtensions._
 import org.scalatest.{Matchers, WordSpec}
 
 import scala.collection.{immutable => im}
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe.TypeTag
 
 class ScalaMapBinderSpec extends WordSpec with Matchers {
   private case class W[T](t: T)
@@ -363,7 +365,7 @@ class ScalaMapBinderSpec extends WordSpec with Matchers {
     }
   }
 
-  private def validate[K: Manifest, V: Manifest](module: Module, expected: (K, V)*): Unit = {
+  private def validate[K: TypeTag, V: TypeTag](module: Module, expected: (K, V)*): Unit = {
     val injector = Guice.createInjector(module)
 
     validate(injector.instance[im.Map[K, V]], expected: _*)
@@ -371,7 +373,7 @@ class ScalaMapBinderSpec extends WordSpec with Matchers {
     validate(injector.instance[im.Map[K, javax.inject.Provider[V]]].mapValues(_.get), expected: _*)
   }
 
-  private def validateWithAnnotation[K: Manifest, V: Manifest](module: Module, annotation: Annotation, expected: (K, V)*): Unit = {
+  private def validateWithAnnotation[K: TypeTag, V: TypeTag](module: Module, annotation: Annotation, expected: (K, V)*): Unit = {
     val injector = Guice.createInjector(module)
 
     validate(injector.instance[im.Map[K, V]](annotation), expected: _*)
@@ -379,7 +381,7 @@ class ScalaMapBinderSpec extends WordSpec with Matchers {
     validate(injector.instance[im.Map[K, javax.inject.Provider[V]]](annotation).mapValues(_.get), expected: _*)
   }
 
-  private def validateWithAnn[K: Manifest, V: Manifest, Ann <: Annotation : Manifest](module: Module, expected: (K, V)*): Unit = {
+  private def validateWithAnn[K: TypeTag, V: TypeTag, Ann <: Annotation : ClassTag](module: Module, expected: (K, V)*): Unit = {
     val injector = Guice.createInjector(module)
 
     validate(injector.instance[im.Map[K, V], Ann], expected: _*)
@@ -387,21 +389,21 @@ class ScalaMapBinderSpec extends WordSpec with Matchers {
     validate(injector.instance[im.Map[K, javax.inject.Provider[V]], Ann].mapValues(_.get), expected: _*)
   }
 
-  private def validateMultiMap[K: Manifest, V: Manifest](module: Module, expected: (K, im.Set[V])*): Unit = {
+  private def validateMultiMap[K: TypeTag, V: TypeTag](module: Module, expected: (K, im.Set[V])*): Unit = {
     val injector = Guice.createInjector(module)
 
     validate(injector.instance[im.Map[K, im.Set[V]]], expected: _*)
     validate(injector.instance[im.Map[K, im.Set[Provider[V]]]].mapValues(_.map(_.get)), expected: _*)
   }
 
-  private def validateMultiMapWithAnnotation[K: Manifest, V: Manifest](module: Module, annotation: Annotation, expected: (K, im.Set[V])*): Unit = {
+  private def validateMultiMapWithAnnotation[K: TypeTag, V: TypeTag](module: Module, annotation: Annotation, expected: (K, im.Set[V])*): Unit = {
     val injector = Guice.createInjector(module)
 
     validate(injector.instance[im.Map[K, im.Set[V]]](annotation), expected: _*)
     validate(injector.instance[im.Map[K, im.Set[Provider[V]]]](annotation).mapValues(_.map(_.get)), expected: _*)
   }
 
-  private def validateMultiMapWithAnn[K: Manifest, V: Manifest, Ann <: Annotation : Manifest](module: Module, expected: (K, im.Set[V])*): Unit = {
+  private def validateMultiMapWithAnn[K: TypeTag, V: TypeTag, Ann <: Annotation : ClassTag](module: Module, expected: (K, im.Set[V])*): Unit = {
     val injector = Guice.createInjector(module)
 
     validate(injector.instance[im.Map[K, im.Set[V]], Ann], expected: _*)

--- a/src/test/scala/net/codingwell/scalaguice/ScalaOptionBinderSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/ScalaOptionBinderSpec.scala
@@ -22,6 +22,8 @@ import com.google.inject.name.{Named, Names}
 import com.google.inject.{AbstractModule, Guice, Key, Module, Provider}
 import net.codingwell.scalaguice.InjectorExtensions._
 import org.scalatest.{Matchers, WordSpec}
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe.TypeTag
 
 class ScalaOptionBinderSpec extends WordSpec with Matchers {
   private case class W[T](t: T)
@@ -60,7 +62,7 @@ class ScalaOptionBinderSpec extends WordSpec with Matchers {
         }
       }
 
-      validateWithAnnotation(module, annotation)
+      validateWithAnnotation(module, annotation, expected = "A")
     }
 
     "bind [Class]" in {
@@ -335,7 +337,7 @@ class ScalaOptionBinderSpec extends WordSpec with Matchers {
 
   }
 
-  private def validate[T: Manifest](module: Module, expected: T = "A"): Unit = {
+  private def validate[T: TypeTag](module: Module, expected: T = "A"): Unit = {
     val injector = Guice.createInjector(module)
 
     // Check Option
@@ -349,7 +351,7 @@ class ScalaOptionBinderSpec extends WordSpec with Matchers {
     injector.instance[Optional[javax.inject.Provider[T]]].get.get() should equal(expected)
   }
 
-  private def validateWithAnn[T: Manifest, Ann <: Annotation : Manifest](module: Module, expected: T = "A"): Unit = {
+  private def validateWithAnn[T: TypeTag, Ann <: Annotation : ClassTag](module: Module, expected: T = "A"): Unit = {
     val injector = Guice.createInjector(module)
 
     // Check Option
@@ -363,7 +365,7 @@ class ScalaOptionBinderSpec extends WordSpec with Matchers {
     injector.instance[Optional[javax.inject.Provider[T]], Ann].get.get() should equal(expected)
   }
 
-  private def validateWithAnnotation[T: Manifest](module: Module, annotation: Annotation, expected: T = "A"): Unit = {
+  private def validateWithAnnotation[T: TypeTag](module: Module, annotation: Annotation, expected: T): Unit = {
     val injector = Guice.createInjector(module)
 
     // Check Option
@@ -377,7 +379,7 @@ class ScalaOptionBinderSpec extends WordSpec with Matchers {
     injector.instance[Optional[javax.inject.Provider[T]]](annotation).get.get() should equal(expected)
   }
 
-  private def validateAbsent[T: Manifest](module: Module, expected: T = "A"): Unit = {
+  private def validateAbsent[T: TypeTag](module: Module, expected: T = "A"): Unit = {
     val injector = Guice.createInjector(module)
 
     // Check Option


### PR DESCRIPTION
The `Manifest` class is part of the pre-2.10 reflection API, which has been replaced with the newer `ClassTag` and `TypeTag` classes.

As well as offering a richer mirror-based API, the new classes also seem to resolve a bug with reflection-based class loading in `Manifest`, which interacted badly with Play's DEV mode hot reloading.

Fixes #79