### PR TITLE
TypeConversions support for complex types

### DIFF
--- a/src/main/scala/net/codingwell/scalaguice/TypeConversions.scala
+++ b/src/main/scala/net/codingwell/scalaguice/TypeConversions.scala
@@ -31,6 +31,7 @@ private [scalaguice] object TypeConversions {
     def unapply(tpe: ScalaType): Option[(ClassSymbol, Seq[ScalaType])] = {
       tpe match {
         case TypeRef(pre, sym, args) if sym.isClass => Some((sym.asClass, args))
+        case RefinedType(_, _) => unapply(tpe.erasure)
         case _ => None
       }
 
@@ -58,7 +59,7 @@ private [scalaguice] object TypeConversions {
   def scalaTypeToJavaType(scalaType: ScalaType, mirror: Mirror, allowPrimative: Boolean = false): JavaType = {
     scalaType.dealias match {
       case `anyType` => classOf[java.lang.Object]
-      case ExistentialType(symbols, underlying) => scalaTypeToJavaType(underlying, mirror)
+      case ExistentialType(_, underlying) => scalaTypeToJavaType(underlying, mirror)
       case ArrayType(argType) => arrayOf(scalaTypeToJavaType(argType, mirror, allowPrimative=true))
       case ClassType(symbol, args) => {
         val rawType = mirror.runtimeClass(symbol)

--- a/src/test/scala/net/codingwell/scalaguice/BindingExtensionsSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/BindingExtensionsSpec.scala
@@ -68,5 +68,19 @@ class BindingExtensionsSpec extends WordSpec with Matchers {
       } getInstance new Key[Gen[String]] {}
       inst.get should equal ("String")
     }
+
+    "allow binding complex type" in {
+      val inst = Guice createInjector module { binder =>
+        binder.bindType[SomeClazz with Augmentation].toInstance(new SomeClazz with Augmentation)
+      } getInstance classOf[SomeClazz]
+      inst.get should equal("String with trait augmentation")
+    }
+
+    "allow binding complex type with type alias" in {
+      val inst = Guice createInjector module { binder =>
+        binder.bindType[Testing.SomeClazzWithAugmentation].toInstance(new SomeClazz with Augmentation)
+      } getInstance classOf[SomeClazz]
+      inst.get should equal("String with trait augmentation")
+    }
   }
 }

--- a/src/test/scala/net/codingwell/scalaguice/ClassesForTesting.scala
+++ b/src/test/scala/net/codingwell/scalaguice/ClassesForTesting.scala
@@ -93,3 +93,16 @@ case class SealedTraitContainer[T <: SealedTrait](inner: T)
 class SealedTraitContainerFinalSealedTraitProvider extends javax.inject.Provider[SealedTraitContainer[FinalSealedTrait.type]] {
   def get(): SealedTraitContainer[FinalSealedTrait.type] = SealedTraitContainer(FinalSealedTrait)
 }
+
+class SomeClazz {
+  protected val underlying: String = "String"
+  def get: String = underlying
+}
+
+trait Augmentation { self: SomeClazz =>
+  override def get: String = s"${self.underlying} with trait augmentation"
+}
+
+object Testing {
+  type SomeClazzWithAugmentation = SomeClazz with Augmentation
+}

--- a/src/test/scala/net/codingwell/scalaguice/TypeLiteralSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/TypeLiteralSpec.scala
@@ -15,7 +15,8 @@
  */
 package net.codingwell.scalaguice
 
-import org.scalatest.{Matchers, FunSpec}
+import net.codingwell.scalaguice.Testing.SomeClazzWithAugmentation
+import org.scalatest.{FunSpec, Matchers}
 
 class TypeLiteralSpec extends FunSpec with Matchers {
 
@@ -122,6 +123,15 @@ class TypeLiteralSpec extends FunSpec with Matchers {
     
     it("Should handle explicit function"){
       typeLiteral[Function1[Function0[Unit],String]] shouldEqual new TypeLiteral[(=> Unit) => String] {}
+    }
+
+    it("should handle complex type") {
+      typeLiteral[SomeClazz with Augmentation] shouldEqual new TypeLiteral[SomeClazz with Augmentation] {}
+    }
+
+    it("should handle complex type via type alias") {
+      typeLiteral[SomeClazzWithAugmentation] shouldEqual new TypeLiteral[SomeClazzWithAugmentation] {}
+      typeLiteral[SomeClazzWithAugmentation] shouldEqual new TypeLiteral[SomeClazz with Augmentation] {}
     }
   }
 }


### PR DESCRIPTION
Problem

It is not currently possible to support building a `TypeLiteral` from
a complex Scala type, e.g., `Foo with Trait`.

Solution

Add a case statement in the `net.codingwell.scalaguice.ClassType#unapply`
to match on a `scala.reflect.internal.RefinedType` which is defined as a
class representing the intersection of types with refinements of the form
`parents0 with parentsN`. Then use this as signal to process the erasure
form of the type passing it back through the unapply.

Add test cases. This addresses #87.