### PR TITLE
Patch TypeConversions to support Nothing type

### DIFF
--- a/src/main/scala/net/codingwell/scalaguice/TypeConversions.scala
+++ b/src/main/scala/net/codingwell/scalaguice/TypeConversions.scala
@@ -13,6 +13,7 @@ import scala.reflect.runtime.universe.{Type => ScalaType, _}
   */
 private [scalaguice] object TypeConversions {
   private val anyType = typeOf[Any]
+  private val nothingType = typeOf[Nothing]
 
   object ArrayType {
     private val arraySymbol = symbolOf[Array[_]]
@@ -55,12 +56,13 @@ private [scalaguice] object TypeConversions {
     }
 
   }
-  
+
   //https://github.com/scala/scala/blob/98b9a1c19ba2b7b342bc9b838628b86d00276540/src/reflect/scala/reflect/internal/Types.scala#L31
 
   def scalaTypeToJavaType(scalaType: ScalaType, mirror: Mirror, allowPrimative: Boolean = false): JavaType = {
     scalaType.dealias match {
-      case `anyType` => classOf[java.lang.Object]
+      case `anyType`     => classOf[java.lang.Object]
+      case `nothingType` => classOf[scala.runtime.Nothing$]
       case ExistentialType(_, underlying) => scalaTypeToJavaType(underlying, mirror)
       case ArrayType(argType) => arrayOf(scalaTypeToJavaType(argType, mirror, allowPrimative=true))
       case ClassType(symbol, args) => {

--- a/src/test/scala/net/codingwell/scalaguice/BindingExtensionsSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/BindingExtensionsSpec.scala
@@ -16,15 +16,15 @@
 package net.codingwell.scalaguice
 
 import org.scalatest.{Matchers, WordSpec}
-
 import com.google.inject._
+import scala.util.Try
 
 class BindingExtensionsSpec extends WordSpec with Matchers {
 
   import BindingExtensions._
 
-  def module(body: Binder => Unit) =  new Module {
-      def configure(binder: Binder) = body(binder)
+  def module(body: Binder => Unit): Module = new Module {
+    def configure(binder: Binder): Unit = body(binder)
   }
 
   "Binding extensions" should {
@@ -81,6 +81,19 @@ class BindingExtensionsSpec extends WordSpec with Matchers {
         binder.bindType[Testing.SomeClazzWithAugmentation].toInstance(new SomeClazz with Augmentation)
       } getInstance classOf[SomeClazz]
       inst.get should equal("String with trait augmentation")
+    }
+
+    "allow binding with Nothing type" in {
+      import net.codingwell.scalaguice.KeyExtensions._
+
+      val e: Either[Try[Nothing], Nothing] = Left(Try(throw new Exception))
+
+      val inst = Guice createInjector module { binder =>
+        binder
+          .bindType[Either[Try[Nothing], Nothing]]
+          .toInstance(e)
+      } getInstance typeLiteral[Either[Try[Nothing], Nothing]].toKey
+      inst should equal(e)
     }
   }
 }


### PR DESCRIPTION
Problem

The Scala `Nothing` type is not properly supported when building a TypeLiteral.

Solution

Add a case in the `net.codingwell.scalaguice.TypeConversions#scalaTypeToJavaType` to 
handle converting the Scala `Nothing` type to a Java type. Add a test case.

This fixes #95.