### PR TITLE
Update to Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ libraryDependencies ++= Seq(
   "org.scala-lang" % "scala-reflect" % scalaVersion.value
 )
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.2" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.9" % "test"
 
 libraryDependencies += "com.google.code.findbugs" % "jsr305" % "3.0.2" % "compile"
 

--- a/build.sbt
+++ b/build.sbt
@@ -15,17 +15,27 @@ libraryDependencies ++= Seq(
   "org.scala-lang" % "scala-reflect" % scalaVersion.value
 )
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.2" % "test"
 
 libraryDependencies += "com.google.code.findbugs" % "jsr305" % "3.0.2" % "compile"
 
+libraryDependencies += "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.2"
+
 autoAPIMappings := true
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.13.6"
 
-crossScalaVersions := Seq("2.11.12", "2.12.13", "2.13.5")
+crossScalaVersions := Seq("2.11.12", "2.12.13", "2.13.6")
 
 scalacOptions := Seq("-unchecked", "-deprecation", "-feature")
+
+Compile / unmanagedSourceDirectories += {
+  val sourceDir = (Compile / sourceDirectory).value
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, n)) if n >= 13 => sourceDir / "scala-2.13+"
+    case _ => sourceDir / "scala-2.12-"
+  }
+}
 
 publishTo := {
   val nexus = "https://oss.sonatype.org/"

--- a/src/main/scala-2.12-/net/codingwell/scalaguice/MapProvider.scala
+++ b/src/main/scala-2.12-/net/codingwell/scalaguice/MapProvider.scala
@@ -15,13 +15,10 @@
  */
 package net.codingwell.scalaguice
 
-import java.util
-import java.util.{Map => JMap, Set => JSet}
-
 import com.google.common.collect.ImmutableSet
 import com.google.inject.spi.{Dependency, ProviderWithDependencies}
 import com.google.inject.{Inject, Injector, Key}
-
+import java.util.{Map => JMap, Set => JSet}
 import scala.collection.JavaConverters._
 import scala.collection.{immutable => im}
 
@@ -41,7 +38,7 @@ class MapProvider[K, V](source: Key[JMap[K, V]]) extends ProviderWithDependencie
     map.asScala.toMap[K, V]
   }
 
-  override def getDependencies: util.Set[Dependency[_]] = {
+  override def getDependencies: JSet[Dependency[_]] = {
     ImmutableSet.of(Dependency.get(source))
   }
 }
@@ -62,7 +59,7 @@ class MapOfKToSetOfVProvider[K, V](source: Key[JMap[K, JSet[V]]]) extends Provid
     map.asScala.mapValues(s => s.asScala.toSet[V]).toMap[K, im.Set[V]]
   }
 
-  override def getDependencies: util.Set[Dependency[_]] = {
+  override def getDependencies: JSet[Dependency[_]] = {
     ImmutableSet.of(Dependency.get(source))
   }
 }

--- a/src/main/scala-2.12-/net/codingwell/scalaguice/SetProvider.scala
+++ b/src/main/scala-2.12-/net/codingwell/scalaguice/SetProvider.scala
@@ -1,5 +1,6 @@
 /*
  *  Copyright 2010-2014 Benjamin Lings
+ *  Author: Thomas Suckow
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,29 +16,30 @@
  */
 package net.codingwell.scalaguice
 
-import com.google.common.base.Optional
 import com.google.common.collect.ImmutableSet
-import com.google.inject.spi.{Dependency, ProviderWithDependencies}
-import com.google.inject.{Inject, Injector, Key}
-import java.util
+import com.google.inject._
+import com.google.inject.spi._
+import java.util.{Set => JSet}
+import scala.collection.JavaConverters._
+import scala.collection.{immutable => im}
 
 /**
- * Provider for Scala's Option from Guava's Optional.
+ * Provider for a Scala Immutable Set from a Java Set.
  *
  * Example:
  * {{{
- * .toProvider(new OptionProvider[T](Key.get(typeLiteral[Optional[T]])))
+ * .toProvider( new SetProvider[T]( Key.get( typeLiteral[JSet[T]] ) ) )
  * }}}
  */
-class OptionProvider[T] (source: Key[Optional[T]]) extends ProviderWithDependencies[Option[T]] {
-  @Inject() private[this] val injector: Injector = null
+class SetProvider[T] (val source:Key[JSet[T]]) extends ProviderWithDependencies[im.Set[T]] {
 
-  override def get(): Option[T] = {
-    val opt = injector.getInstance(source)
-    if (opt.isPresent) Some(opt.get) else None
+  @Inject() var injector:Injector = null
+
+  def get():im.Set[T] = {
+    injector.getInstance( source ).asScala.toSet[T]
   }
 
-  override def getDependencies: util.Set[Dependency[_]] = {
-    ImmutableSet.of(Dependency.get(source))
+  def getDependencies = {
+    ImmutableSet.of( Dependency.get( source ) )
   }
 }

--- a/src/main/scala-2.12-/net/codingwell/scalaguice/SetProvider.scala
+++ b/src/main/scala-2.12-/net/codingwell/scalaguice/SetProvider.scala
@@ -33,7 +33,7 @@ import scala.collection.{immutable => im}
  */
 class SetProvider[T] (val source:Key[JSet[T]]) extends ProviderWithDependencies[im.Set[T]] {
 
-  @Inject() var injector:Injector = null
+  @Inject() var injector:Injector = _
 
   def get():im.Set[T] = {
     injector.getInstance( source ).asScala.toSet[T]

--- a/src/main/scala-2.13+/net/codingwell/scalaguice/MapProvider.scala
+++ b/src/main/scala-2.13+/net/codingwell/scalaguice/MapProvider.scala
@@ -1,0 +1,65 @@
+/*
+ *  Copyright 2010-2014 Benjamin Lings
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.codingwell.scalaguice
+
+import com.google.common.collect.ImmutableSet
+import com.google.inject.spi.{Dependency, ProviderWithDependencies}
+import com.google.inject.{Inject, Injector, Key}
+import java.util.{Map => JMap, Set => JSet}
+import scala.collection.{immutable => im}
+import scala.jdk.CollectionConverters._
+
+/**
+ * Provider for a Scala Immutable Map from a Java Map.
+ *
+ * Example:
+ * {{{
+ * .toProvider(new MapProvider[K, V](Key.get(typeLiteral[JMap[K, V]])))
+ * }}}
+ */
+class MapProvider[K, V](source: Key[JMap[K, V]]) extends ProviderWithDependencies[im.Map[K, V]] {
+  @Inject() private[this] val injector: Injector = null
+
+  override def get(): im.Map[K, V] = {
+    val map = injector.getInstance(source)
+    map.asScala.toMap[K, V]
+  }
+
+  override def getDependencies: JSet[Dependency[_]] = {
+    ImmutableSet.of(Dependency.get(source))
+  }
+}
+
+/**
+ * Provider for a Scala Immutable Map from a Java Map.
+ *
+ * Example:
+ * {{{
+ * .toProvider(new MapOfKToSetOfVProvider[K, V](Key.get(typeLiteral[JMap[K, JSet[V]]])))
+ * }}}
+ */
+class MapOfKToSetOfVProvider[K, V](source: Key[JMap[K, JSet[V]]]) extends ProviderWithDependencies[im.Map[K, im.Set[V]]] {
+  @Inject() private[this] val injector: Injector = null
+
+  override def get(): im.Map[K, im.Set[V]] = {
+    val map = injector.getInstance(source)
+    map.asScala.view.mapValues(s => s.asScala.toSet[V]).toMap[K, im.Set[V]]
+  }
+
+  override def getDependencies: JSet[Dependency[_]] = {
+    ImmutableSet.of(Dependency.get(source))
+  }
+}

--- a/src/main/scala-2.13+/net/codingwell/scalaguice/SetProvider.scala
+++ b/src/main/scala-2.13+/net/codingwell/scalaguice/SetProvider.scala
@@ -33,7 +33,7 @@ import scala.jdk.CollectionConverters._
  */
 class SetProvider[T] (val source:Key[JSet[T]]) extends ProviderWithDependencies[im.Set[T]] {
 
-  @Inject() var injector:Injector = null
+  @Inject() var injector:Injector = _
 
   def get():im.Set[T] = {
     injector.getInstance( source ).asScala.toSet[T]

--- a/src/main/scala-2.13+/net/codingwell/scalaguice/SetProvider.scala
+++ b/src/main/scala-2.13+/net/codingwell/scalaguice/SetProvider.scala
@@ -19,11 +19,9 @@ package net.codingwell.scalaguice
 import com.google.common.collect.ImmutableSet
 import com.google.inject._
 import com.google.inject.spi._
-
 import java.util.{Set => JSet}
-
-import scala.collection.JavaConverters._
-import scala.collection.{ immutable => im }
+import scala.collection.{immutable => im}
+import scala.jdk.CollectionConverters._
 
 /**
  * Provider for a Scala Immutable Set from a Java Set.

--- a/src/main/scala/net/codingwell/package.scala
+++ b/src/main/scala/net/codingwell/package.scala
@@ -15,15 +15,13 @@
  */
 package net.codingwell
 
-import java.lang.annotation.Annotation
-
 import com.google.inject.internal.Annotations
 import com.google.inject.util.Types.newParameterizedType
 import com.google.inject.{Key, TypeLiteral}
-
+import java.lang.annotation.Annotation
 import scala.language.higherKinds
-import scala.reflect.{ClassTag, classTag}
 import scala.reflect.runtime.universe.{TypeTag, typeOf}
+import scala.reflect.{ClassTag, classTag}
 
 
 package object scalaguice {
@@ -38,7 +36,7 @@ package object scalaguice {
     TypeLiteral.get(javaType).asInstanceOf[TypeLiteral[T]]
   }
 
-  def cls[T: ClassTag] = classTag[T].runtimeClass.asInstanceOf[Class[T]]
+  def cls[T: ClassTag]: Class[T] = classTag[T].runtimeClass.asInstanceOf[Class[T]]
 
   /**
    * Returns the name the set should use.  This is based on the annotation.

--- a/src/main/scala/net/codingwell/scalaguice/BindingExtensions.scala
+++ b/src/main/scala/net/codingwell/scalaguice/BindingExtensions.scala
@@ -19,10 +19,9 @@ import com.google.inject.Binder
 import com.google.inject.binder._
 import com.google.inject.name.Names
 import java.lang.annotation.{Annotation => JAnnotation}
+import javax.inject.Provider
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
-
-import javax.inject.Provider
 
 /**
  * Extensions for Guice's binding DSL.

--- a/src/main/scala/net/codingwell/scalaguice/InjectorExtensions.scala
+++ b/src/main/scala/net/codingwell/scalaguice/InjectorExtensions.scala
@@ -17,7 +17,7 @@ package net.codingwell.scalaguice
 
 import com.google.inject.{Binding, Injector, Key, Provider}
 import java.lang.annotation.Annotation
-import KeyExtensions._
+import net.codingwell.scalaguice.KeyExtensions._
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
 

--- a/src/main/scala/net/codingwell/scalaguice/KeyExtensions.scala
+++ b/src/main/scala/net/codingwell/scalaguice/KeyExtensions.scala
@@ -16,8 +16,8 @@
 package net.codingwell.scalaguice
 
 import com.google.inject._
-import java.lang.annotation.{Annotation => JAnnotation}
 import com.google.inject.name.Names
+import java.lang.annotation.{Annotation => JAnnotation}
 import scala.reflect.ClassTag
 
 object KeyExtensions {

--- a/src/main/scala/net/codingwell/scalaguice/ScalaMapBinder.scala
+++ b/src/main/scala/net/codingwell/scalaguice/ScalaMapBinder.scala
@@ -15,16 +15,14 @@
  */
 package net.codingwell.scalaguice
 
-import java.lang.annotation.Annotation
-import java.util.{Map => JMap, Set => JSet}
-
 import com.google.inject.multibindings.MapBinder
 import com.google.inject.{Binder, Key, Module, Provider, TypeLiteral}
+import java.lang.annotation.Annotation
+import java.util.{Map => JMap, Set => JSet}
 import net.codingwell.scalaguice.ScalaModule.ScalaLinkedBindingBuilder
-
-import scala.reflect.runtime.universe.TypeTag
 import scala.collection.{immutable => im}
 import scala.reflect.ClassTag
+import scala.reflect.runtime.universe.TypeTag
 
 /**
  * Analog to Guice's MapBinder
@@ -183,7 +181,7 @@ object ScalaMapBinder {
    */
   private class RealScalaMapBinder[K, V](parent: MapBinder[K, V], kTyp: TypeLiteral[K], vTyp: TypeLiteral[V],
                                          annotatedKey: Key[_]) extends ScalaMapBinder[K, V] with Module {
-    val mapKey = annotatedKey.ofType(wrap2[im.Map].around(kTyp, vTyp))
+    val mapKey: Key[Map[K, V]] = annotatedKey.ofType(wrap2[im.Map].around(kTyp, vTyp))
     private[this] val mapName = nameOf(mapKey)
     private def scalaMapKey: Key[im.Map[K, V]] = mapKey
 

--- a/src/main/scala/net/codingwell/scalaguice/ScalaMultibinder.scala
+++ b/src/main/scala/net/codingwell/scalaguice/ScalaMultibinder.scala
@@ -16,13 +16,11 @@
  */
 package net.codingwell.scalaguice
 
-import java.lang.annotation.Annotation
-import java.util.{Set => JSet}
-
 import com.google.inject.multibindings.Multibinder
 import com.google.inject.{Binder, Key, Module, TypeLiteral}
+import java.lang.annotation.Annotation
+import java.util.{Set => JSet}
 import net.codingwell.scalaguice.ScalaModule.ScalaLinkedBindingBuilder
-
 import scala.collection.{immutable => im}
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
@@ -64,7 +62,7 @@ object ScalaMultibinder {
    * Returns a new multibinder that collects instances of type `T` in a [[scala.collection.immutable.Set]] that is
    * itself bound with no binding annotation.
    */
-  def newSetBinder[T: TypeTag](binder: Binder) = {
+  def newSetBinder[T: TypeTag](binder: Binder): ScalaMultibinder[T] = {
     newMultibinder(binder, typeLiteral[T])
   }
 
@@ -72,7 +70,7 @@ object ScalaMultibinder {
    * Returns a new multibinder that collects instances of type `T` in a [[scala.collection.immutable.Set]] that is
    * itself bound with a binding annotation `Ann`.
    */
-  def newSetBinder[T: TypeTag, Ann <: Annotation : ClassTag](binder: Binder) = {
+  def newSetBinder[T: TypeTag, Ann <: Annotation : ClassTag](binder: Binder): ScalaMultibinder[T] = {
     newMultibinder[T, Ann](binder, typeLiteral[T], cls[Ann])
   }
 
@@ -80,7 +78,7 @@ object ScalaMultibinder {
    * Returns a new multibinder that collects instances of type `T` in a [[scala.collection.immutable.Set]] that is
    * itself bound with a binding annotation.
    */
-  def newSetBinder[T: TypeTag](binder: Binder, annotation: Annotation) = {
+  def newSetBinder[T: TypeTag](binder: Binder, annotation: Annotation): ScalaMultibinder[T] = {
     newMultibinder(binder, typeLiteral[T], annotation)
   }
 
@@ -90,7 +88,7 @@ object ScalaMultibinder {
    * Returns a new multibinder that collects instances of `typ` in a [[scala.collection.immutable.Set]] that is
    * itself bound with no binding annotation.
    */
-  def newSetBinder[T](binder: Binder, typ: TypeLiteral[T]) = {
+  def newSetBinder[T](binder: Binder, typ: TypeLiteral[T]): ScalaMultibinder[T] = {
     newMultibinder(binder, typ)
   }
 
@@ -99,7 +97,7 @@ object ScalaMultibinder {
    * itself bound with no binding annotation. Note that `typ` is ignored in favor of using the `T` TypeTag to capture
    * type arguments.
    */
-  def newSetBinder[T: TypeTag](binder: Binder, typ: Class[T]) = {
+  def newSetBinder[T: TypeTag](binder: Binder, typ: Class[T]): ScalaMultibinder[T] = {
     newMultibinder(binder, typeLiteral[T])
   }
 
@@ -107,7 +105,7 @@ object ScalaMultibinder {
    * Returns a new multibinder that collects instances of `typ` in a [[scala.collection.immutable.Set]] that is
    * itself bound with a binding annotation.
    */
-  def newSetBinder[T: TypeTag](binder: Binder, typ: TypeLiteral[T], annotation: Annotation) = {
+  def newSetBinder[T: TypeTag](binder: Binder, typ: TypeLiteral[T], annotation: Annotation): ScalaMultibinder[T] = {
     newMultibinder(binder, typ, annotation)
   }
 
@@ -116,7 +114,7 @@ object ScalaMultibinder {
    * itself bound with a binding annotation. Note that `typ` is ignored in favor of using the TypeTag to capture
    * type arguments.
    */
-  def newSetBinder[T: TypeTag](binder: Binder, typ: Class[T], annotation: Annotation) = {
+  def newSetBinder[T: TypeTag](binder: Binder, typ: Class[T], annotation: Annotation): ScalaMultibinder[T] = {
     newMultibinder(binder, typeLiteral[T], annotation)
   }
 
@@ -124,7 +122,7 @@ object ScalaMultibinder {
    * Returns a new multibinder that collects instances of `typ` in a [[scala.collection.immutable.Set]] that is
    * itself bound with a binding annotation.
    */
-  def newSetBinder[T](binder: Binder, typ: TypeLiteral[T], annotation: Class[_ <: Annotation]) = {
+  def newSetBinder[T](binder: Binder, typ: TypeLiteral[T], annotation: Class[_ <: Annotation]): ScalaMultibinder[T] = {
     newMultibinder(binder, typ, annotation)
   }
 
@@ -133,7 +131,7 @@ object ScalaMultibinder {
    * itself bound with a binding annotation. Note that `typ` is ignored in favor of using the TypeTag to capture
    * type arguments.
    */
-  def newSetBinder[T: TypeTag](binder: Binder, typ: Class[T], annotation: Class[_ <: Annotation]) = {
+  def newSetBinder[T: TypeTag](binder: Binder, typ: Class[T], annotation: Class[_ <: Annotation]): ScalaMultibinder[T] = {
     newMultibinder(binder, typeLiteral[T], annotation)
   }
 

--- a/src/main/scala/net/codingwell/scalaguice/ScalaOptionBinder.scala
+++ b/src/main/scala/net/codingwell/scalaguice/ScalaOptionBinder.scala
@@ -15,13 +15,11 @@
  */
 package net.codingwell.scalaguice
 
-import java.lang.annotation.Annotation
-
 import com.google.common.base.Optional
 import com.google.inject.multibindings.OptionalBinder
 import com.google.inject.{Binder, Key, Module, Provider, TypeLiteral}
+import java.lang.annotation.Annotation
 import net.codingwell.scalaguice.ScalaModule.ScalaLinkedBindingBuilder
-
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 

--- a/src/main/scala/net/codingwell/scalaguice/binder/BindingProxies.scala
+++ b/src/main/scala/net/codingwell/scalaguice/binder/BindingProxies.scala
@@ -16,26 +16,32 @@
 package net.codingwell.scalaguice
 package binder
 
-import scala.language.postfixOps
-
 import com.google.inject._
 import com.google.inject.binder._
+import com.google.inject.name.Names
 import java.lang.annotation.{Annotation => JAnnotation}
 import java.lang.reflect.{Constructor => JConstructor}
 import net.codingwell.scalaguice.ScalaModule.{ScalaLinkedBindingBuilder, ScalaScopedBindingBuilder}
-import com.google.inject.name.Names
+import scala.language.postfixOps
 
 /**
  * Proxy for com.google.inject.binder.ScopedBindingBuilder
  */
-trait ScopedBindingBuilderProxy extends ScopedBindingBuilder
-                          with Proxy {
+trait ScopedBindingBuilderProxy extends ScopedBindingBuilder {
 
-  override def self: ScopedBindingBuilder
+  def self: ScopedBindingBuilder
 
-  def asEagerSingleton() = self asEagerSingleton
-  def in(scope: Scope) = self in scope
-  def in(scopeAnnotation: Class[_ <: JAnnotation]) = self in scopeAnnotation
+  def asEagerSingleton(): Unit = self.asEagerSingleton()
+  def in(scope: Scope): Unit = self.in(scope)
+  def in(scopeAnnotation: Class[_ <: JAnnotation]): Unit = self.in(scopeAnnotation)
+  override def hashCode: Int = self.hashCode
+  override def equals(that: Any): Boolean = that match {
+    case null  => false
+    case _     =>
+      val x = that.asInstanceOf[AnyRef]
+      (x eq this.asInstanceOf[AnyRef]) || (x eq self.asInstanceOf[AnyRef]) || (x equals self)
+  }
+  override def toString: String = "" + self
 }
 
 /**
@@ -44,18 +50,18 @@ trait ScopedBindingBuilderProxy extends ScopedBindingBuilder
 trait LinkedBindingBuilderProxy[T] extends LinkedBindingBuilder[T] with ScopedBindingBuilderProxy {
   override def self: LinkedBindingBuilder[T]
 
-  override def toInstance(instance: T) = self toInstance instance
+  override def toInstance(instance: T): Unit = self.toInstance(instance)
 
-  override def to(implementation: Class[_ <: T]) = newBuilder(self to implementation)
-  override def to(implementation: TypeLiteral[_ <: T]) = newBuilder(self to implementation)
-  override def to(targetKey: Key[_ <: T]) = newBuilder(self to targetKey)
-  override def toConstructor[S <: T](constructor:JConstructor[S]) = newBuilder(self toConstructor constructor)
-  override def toConstructor[S <: T](constructor:JConstructor[S], literal:TypeLiteral[_ <: S]) = newBuilder(self toConstructor(constructor,literal))
-  override def toProvider(provider: Provider[_ <: T]) = newBuilder(self toProvider provider)
-  override def toProvider(provider: javax.inject.Provider[_ <: T]) = newBuilder(self toProvider provider)
-  override def toProvider(provider: Class[_ <: javax.inject.Provider[_ <: T]]) = newBuilder(self toProvider provider)
-  override def toProvider(provider: TypeLiteral[_ <: javax.inject.Provider[_ <: T]]) = newBuilder(self toProvider provider)
-  override def toProvider(providerKey: Key[_ <: javax.inject.Provider[_ <: T]]) = newBuilder(self toProvider providerKey)
+  override def to(implementation: Class[_ <: T]) = newBuilder(self.to(implementation))
+  override def to(implementation: TypeLiteral[_ <: T]) = newBuilder(self.to(implementation))
+  override def to(targetKey: Key[_ <: T]) = newBuilder(self.to(targetKey))
+  override def toConstructor[S <: T](constructor:JConstructor[S]) = newBuilder(self.toConstructor(constructor))
+  override def toConstructor[S <: T](constructor:JConstructor[S], literal:TypeLiteral[_ <: S]) = newBuilder(self.toConstructor(constructor,literal))
+  override def toProvider(provider: Provider[_ <: T]) = newBuilder(self.toProvider(provider))
+  override def toProvider(provider: javax.inject.Provider[_ <: T]) = newBuilder(self.toProvider(provider))
+  def toProvider(provider: Class[_ <: javax.inject.Provider[_ <: T]]) = newBuilder(self.toProvider(provider))
+  def toProvider(provider: TypeLiteral[_ <: javax.inject.Provider[_ <: T]]) = newBuilder(self.toProvider(provider))
+  def toProvider(providerKey: Key[_ <: javax.inject.Provider[_ <: T]]) = newBuilder(self.toProvider(providerKey))
 
   private[this] def newBuilder(underlying: ScopedBindingBuilder) = new ScalaScopedBindingBuilder {
     val self = underlying
@@ -68,8 +74,8 @@ trait LinkedBindingBuilderProxy[T] extends LinkedBindingBuilder[T] with ScopedBi
 trait AnnotatedBindingBuilderProxy[T] extends AnnotatedBindingBuilder[T] with LinkedBindingBuilderProxy[T] {
   override def self: AnnotatedBindingBuilder[T]
 
-  def annotatedWith(annotation: JAnnotation) = newBuilder(self annotatedWith annotation)
-  def annotatedWith(annotationType: Class[_ <: JAnnotation]) = newBuilder(self annotatedWith annotationType)
+  def annotatedWith(annotation: JAnnotation) = newBuilder(self.annotatedWith(annotation))
+  def annotatedWith(annotationType: Class[_ <: JAnnotation]) = newBuilder(self.annotatedWith(annotationType))
   def annotatedWithName(name: String) = annotatedWith(Names.named(name))
 
   private[this] def newBuilder(underlying: LinkedBindingBuilder[T]) = new ScalaLinkedBindingBuilder[T] {
@@ -80,10 +86,18 @@ trait AnnotatedBindingBuilderProxy[T] extends AnnotatedBindingBuilder[T] with Li
 /**
  * Proxy for com.google.inject.binder.AnnotatedElementBuilder
  */
-trait AnnotatedElementBuilderProxy[T] extends AnnotatedElementBuilder with Proxy {
-  override def self: AnnotatedElementBuilder
+trait AnnotatedElementBuilderProxy[T] extends AnnotatedElementBuilder {
+  def self: AnnotatedElementBuilder
 
-  def annotatedWith(annotation: JAnnotation) = self annotatedWith annotation
-  def annotatedWith(annotationType: Class[_ <: JAnnotation]) = self annotatedWith annotationType
-  def annotatedWithName(name: String) = annotatedWith(Names.named(name))
+  def annotatedWith(annotation: JAnnotation): Unit = self.annotatedWith(annotation)
+  def annotatedWith(annotationType: Class[_ <: JAnnotation]): Unit = self.annotatedWith(annotationType)
+  def annotatedWithName(name: String): Unit = annotatedWith(Names.named(name))
+  override def hashCode: Int = self.hashCode
+  override def equals(that: Any): Boolean = that match {
+    case null  => false
+    case _     =>
+      val x = that.asInstanceOf[AnyRef]
+      (x eq this.asInstanceOf[AnyRef]) || (x eq self.asInstanceOf[AnyRef]) || (x equals self)
+  }
+  override def toString: String = "" + self
 }

--- a/src/test/scala/net/codingwell/scalaguice/BindingExtensionsSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/BindingExtensionsSpec.scala
@@ -15,11 +15,12 @@
  */
 package net.codingwell.scalaguice
 
-import org.scalatest.{Matchers, WordSpec}
 import com.google.inject._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import scala.util.Try
 
-class BindingExtensionsSpec extends WordSpec with Matchers {
+class BindingExtensionsSpec extends AnyWordSpec with Matchers {
 
   import BindingExtensions._
 

--- a/src/test/scala/net/codingwell/scalaguice/InjectorExtensionsSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/InjectorExtensionsSpec.scala
@@ -17,16 +17,17 @@ package net.codingwell.scalaguice
 
 import com.google.inject.name.Named
 import com.google.inject.name.Names.named
-import com.google.inject.{AbstractModule, Guice}
+import com.google.inject.{AbstractModule, Guice, Injector, Key}
 import net.codingwell.scalaguice.InjectorExtensions._
 import net.codingwell.scalaguice.KeyExtensions._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import scala.reflect.runtime.universe.TypeTag
 
-class InjectorExtensionsSpec extends WordSpec with Matchers {
+class InjectorExtensionsSpec extends AnyWordSpec with Matchers {
 
   val module = new AbstractModule with ScalaModule {
-    override def configure() = {
+    override def configure(): Unit = {
       bind[A].to[B]
       bind[A].annotatedWith(named("d")).to[B]
       bind[B].annotatedWith(classOf[Named]).to[B]
@@ -34,7 +35,7 @@ class InjectorExtensionsSpec extends WordSpec with Matchers {
     }
   }
 
-  val injector = Guice createInjector module
+  val injector: Injector = Guice.createInjector(module)
 
   /** These functionality from theses tests are at compile-time. **/
   "Injector extensions" should {
@@ -84,8 +85,8 @@ class InjectorExtensionsSpec extends WordSpec with Matchers {
       injector.existingBinding[A](named("foo")) should not be defined
     }
 
-    def keyExistsFn[T: TypeTag] = typeLiteral[T].toKey
-    def keyMissingFn[T: TypeTag] = typeLiteral[T].annotatedWithName("foo")
+    def keyExistsFn[T: TypeTag]: Key[T] = typeLiteral[T].toKey
+    def keyMissingFn[T: TypeTag]: Key[T] = typeLiteral[T].annotatedWithName("foo")
 
     "allow existing bindings to be retrieved by key optionally" in {
       val Some(binding) = injector.existingBinding[A](keyExistsFn[A])

--- a/src/test/scala/net/codingwell/scalaguice/KeyExtensionsSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/KeyExtensionsSpec.scala
@@ -2,9 +2,10 @@ package net.codingwell.scalaguice
 
 import com.google.inject.Key
 import com.google.inject.name.{Named, Names}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class KeyExtensionsSpec extends WordSpec with Matchers {
+class KeyExtensionsSpec extends AnyWordSpec with Matchers {
   import KeyExtensions._
 
   private final val TestAnnotation = Names.named("foo")

--- a/src/test/scala/net/codingwell/scalaguice/MapProviderSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/MapProviderSpec.scala
@@ -16,14 +16,14 @@
 package net.codingwell.scalaguice
 
 import com.google.inject.name.Named
-import com.google.inject.{Guice, Key, AbstractModule}
-import org.scalatest.{WordSpec, Matchers}
-
+import com.google.inject.{AbstractModule, Guice, Key}
 import java.util.{Map => JMap, Set => JSet}
+import net.codingwell.scalaguice.InjectorExtensions._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import scala.collection.{immutable => im}
-import InjectorExtensions._
 
-class MapProviderSpec extends WordSpec with Matchers {
+class MapProviderSpec extends AnyWordSpec with Matchers {
   private val testMap = newMap("1" -> 1, "2" -> 2)
   private val testMapToSet = newMap("1" -> newSet(1, 3), "2" -> newSet(2, 4))
 
@@ -98,7 +98,7 @@ class MapProviderSpec extends WordSpec with Matchers {
           bind[im.Map[String, Int]].toProvider(new MapProvider(Key.get(typeLiteral[JMap[String, Int]])))
         }
       }
-      Guice.createInjector(module).instance[im.Map[String, Int]] should be ('empty)
+      Guice.createInjector(module).instance[im.Map[String, Int]] should be (Symbol("empty"))
     }
 
     "allow binding an empty JMap[K, JSet[V]]" in {
@@ -109,7 +109,7 @@ class MapProviderSpec extends WordSpec with Matchers {
           bind[im.Map[String, im.Set[Int]]].toProvider(provider)
         }
       }
-      Guice.createInjector(module).instance[im.Map[String, im.Set[Int]]] should be ('empty)
+      Guice.createInjector(module).instance[im.Map[String, im.Set[Int]]] should be (Symbol("empty"))
     }
   }
 

--- a/src/test/scala/net/codingwell/scalaguice/OptionProviderSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/OptionProviderSpec.scala
@@ -19,9 +19,10 @@ import com.google.common.base.Optional
 import com.google.inject.name.Named
 import com.google.inject.{AbstractModule, Guice, Key}
 import net.codingwell.scalaguice.InjectorExtensions._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class OptionProviderSpec extends WordSpec with Matchers {
+class OptionProviderSpec extends AnyWordSpec with Matchers {
   "An Option Provider" should {
     "allow binding an Optional" in {
       val module = new AbstractModule with ScalaModule {

--- a/src/test/scala/net/codingwell/scalaguice/ScalaMapBinderSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/ScalaMapBinderSpec.scala
@@ -368,44 +368,44 @@ class ScalaMapBinderSpec extends AnyWordSpec with Matchers {
     val injector = Guice.createInjector(module)
 
     validate(injector.instance[im.Map[K, V]], expected: _*)
-    validate(injector.instance[im.Map[K, Provider[V]]].mapValues(_.get), expected: _*)
-    validate(injector.instance[im.Map[K, javax.inject.Provider[V]]].mapValues(_.get), expected: _*)
+    validate(injector.instance[im.Map[K, Provider[V]]].transform { case (_, provider) => provider.get() }, expected: _*)
+    validate(injector.instance[im.Map[K, javax.inject.Provider[V]]].transform { case (_, provider) => provider.get() }, expected: _*)
   }
 
   private def validateWithAnnotation[K: TypeTag, V: TypeTag](module: Module, annotation: Annotation, expected: (K, V)*): Unit = {
     val injector = Guice.createInjector(module)
 
     validate(injector.instance[im.Map[K, V]](annotation), expected: _*)
-    validate(injector.instance[im.Map[K, Provider[V]]](annotation).mapValues(_.get), expected: _*)
-    validate(injector.instance[im.Map[K, javax.inject.Provider[V]]](annotation).mapValues(_.get), expected: _*)
+    validate(injector.instance[im.Map[K, Provider[V]]](annotation).transform { case (_, provider) => provider.get() }, expected: _*)
+    validate(injector.instance[im.Map[K, javax.inject.Provider[V]]](annotation).transform { case (_, provider) => provider.get() }, expected: _*)
   }
 
   private def validateWithAnn[K: TypeTag, V: TypeTag, Ann <: Annotation : ClassTag](module: Module, expected: (K, V)*): Unit = {
     val injector = Guice.createInjector(module)
 
     validate(injector.instance[im.Map[K, V], Ann], expected: _*)
-    validate(injector.instance[im.Map[K, Provider[V]], Ann].mapValues(_.get), expected: _*)
-    validate(injector.instance[im.Map[K, javax.inject.Provider[V]], Ann].mapValues(_.get), expected: _*)
+    validate(injector.instance[im.Map[K, Provider[V]], Ann].transform { case (_, provider) => provider.get() }, expected: _*)
+    validate(injector.instance[im.Map[K, javax.inject.Provider[V]], Ann].transform { case (_, provider) => provider.get() }, expected: _*)
   }
 
   private def validateMultiMap[K: TypeTag, V: TypeTag](module: Module, expected: (K, im.Set[V])*): Unit = {
     val injector = Guice.createInjector(module)
 
     validate(injector.instance[im.Map[K, im.Set[V]]], expected: _*)
-    validate(injector.instance[im.Map[K, im.Set[Provider[V]]]].mapValues(_.map(_.get)), expected: _*)
+    validate(injector.instance[im.Map[K, im.Set[Provider[V]]]].transform { case (_, providers) => providers.map(_.get) }, expected: _*)
   }
 
   private def validateMultiMapWithAnnotation[K: TypeTag, V: TypeTag](module: Module, annotation: Annotation, expected: (K, im.Set[V])*): Unit = {
     val injector = Guice.createInjector(module)
 
     validate(injector.instance[im.Map[K, im.Set[V]]](annotation), expected: _*)
-    validate(injector.instance[im.Map[K, im.Set[Provider[V]]]](annotation).mapValues(_.map(_.get)), expected: _*)
+    validate(injector.instance[im.Map[K, im.Set[Provider[V]]]](annotation).transform { case (_, providers) => providers.map(_.get) }, expected: _*)
   }
 
   private def validateMultiMapWithAnn[K: TypeTag, V: TypeTag, Ann <: Annotation : ClassTag](module: Module, expected: (K, im.Set[V])*): Unit = {
     val injector = Guice.createInjector(module)
 
     validate(injector.instance[im.Map[K, im.Set[V]], Ann], expected: _*)
-    validate(injector.instance[im.Map[K, im.Set[Provider[V]]], Ann].mapValues(_.map(_.get)), expected: _*)
+    validate(injector.instance[im.Map[K, im.Set[Provider[V]]], Ann].transform { case (_, providers) => providers.map(_.get) }, expected: _*)
   }
 }

--- a/src/test/scala/net/codingwell/scalaguice/ScalaMapBinderSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/ScalaMapBinderSpec.scala
@@ -15,18 +15,17 @@
  */
 package net.codingwell.scalaguice
 
-import java.lang.annotation.Annotation
-
 import com.google.inject.name.{Named, Names}
 import com.google.inject.{AbstractModule, CreationException, Guice, Module, Provider}
+import java.lang.annotation.Annotation
 import net.codingwell.scalaguice.InjectorExtensions._
-import org.scalatest.{Matchers, WordSpec}
-
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import scala.collection.{immutable => im}
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 
-class ScalaMapBinderSpec extends WordSpec with Matchers {
+class ScalaMapBinderSpec extends AnyWordSpec with Matchers {
   private case class W[T](t: T)
   private val annotation = Names.named("N")
 

--- a/src/test/scala/net/codingwell/scalaguice/ScalaModuleSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/ScalaModuleSpec.scala
@@ -16,15 +16,16 @@
 package net.codingwell.scalaguice
 
 import com.google.inject._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ScalaModuleSpec extends WordSpec with Matchers {
+class ScalaModuleSpec extends AnyWordSpec with Matchers {
 
   "A Scala Guice module" should {
 
     "allow binding source type using a type parameter" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           bind[A].to(classOf[B])
         }
       }
@@ -33,7 +34,7 @@ class ScalaModuleSpec extends WordSpec with Matchers {
 
     "allow binding target type using a type parameter" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           bind[A].to[B]
         }
       }
@@ -42,7 +43,7 @@ class ScalaModuleSpec extends WordSpec with Matchers {
 
     "allow binding target provider type using a type parameter" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           bind[A].toProvider[BProvider]
         }
       }
@@ -51,7 +52,7 @@ class ScalaModuleSpec extends WordSpec with Matchers {
 
     "allow binding to provider of subtype using type parameter" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           bind[Gen[String]].toProvider[CProvider]
         }
       }
@@ -60,7 +61,7 @@ class ScalaModuleSpec extends WordSpec with Matchers {
 
     "allow binding to provider with injected type literal" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           bind[String].toProvider[TypeProvider[B]]
         }
       }
@@ -69,8 +70,8 @@ class ScalaModuleSpec extends WordSpec with Matchers {
 
     "allow binding in scope using a type parameter" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
-          bind[A].to[B].in[Singleton]
+        override def configure(): Unit = {
+          bind[A].to[B].in[Singleton]()
         }
       }
       Guice.createInjector(module).getInstance(classOf[A])
@@ -78,7 +79,7 @@ class ScalaModuleSpec extends WordSpec with Matchers {
 
     "allow binding a container with a generic singleton type" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           bind[SealedTraitContainer[FinalSealedTrait.type]].toProvider[SealedTraitContainerFinalSealedTraitProvider]
         }
       }
@@ -88,7 +89,7 @@ class ScalaModuleSpec extends WordSpec with Matchers {
     "allow binding with annotation using a type parameter" in {
       import com.google.inject.name.Named
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           bind[A].annotatedWith[Named].to[B]
         }
       }
@@ -106,7 +107,7 @@ class ScalaModuleSpec extends WordSpec with Matchers {
 
     "give a useful error when bound on itself" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           bind[A].to[A]
         }
       }
@@ -122,7 +123,7 @@ class ScalaModuleSpec extends WordSpec with Matchers {
     "allow use annotatedWithName" in {
       import net.codingwell.scalaguice.BindingExtensions._
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           bind[String].annotatedWithName("first").toInstance("first")
           bindConstant().annotatedWithName("second").to("second")
         }
@@ -134,7 +135,7 @@ class ScalaModuleSpec extends WordSpec with Matchers {
 
     "allow binding annotation interceptor" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           bind[Say].to[SayHi]
           bindInterceptor[AOPI](methodMatcher = annotatedWith[AOP])
         }
@@ -148,7 +149,7 @@ class ScalaModuleSpec extends WordSpec with Matchers {
       try { 
       val foo:(=> Unit) => String = (a) => "dog"
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           bind[(=> Unit) => String].toInstance(foo)
           bindInterceptor[AOPI](methodMatcher = annotatedWith[AOP])
         }
@@ -158,7 +159,7 @@ class ScalaModuleSpec extends WordSpec with Matchers {
       val func = injector.instance[(=> Unit) => String]
       func shouldEqual foo
       } catch {
-        case e: Throwable => { e.printStackTrace; throw e }
+        case e: Throwable => { e.printStackTrace(); throw e }
       }
     }
 

--- a/src/test/scala/net/codingwell/scalaguice/ScalaMultibinderSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/ScalaMultibinderSpec.scala
@@ -18,18 +18,18 @@ package net.codingwell.scalaguice
 import com.google.inject.name.{Named, Names}
 import com.google.inject.{AbstractModule, Guice}
 import net.codingwell.scalaguice.InjectorExtensions._
-import org.scalatest.{Matchers, WordSpec}
-
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import scala.collection.{immutable => im}
 
-class ScalaMultibinderSpec extends WordSpec with Matchers {
+class ScalaMultibinderSpec extends AnyWordSpec with Matchers {
   private case class W[T](t: T)
   private val annotation = Names.named("N")
 
   "A multibinder" should {
     "bind empty [T]" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           val multi = ScalaMultibinder.newSetBinder[String](binder)
         }
       }
@@ -38,7 +38,7 @@ class ScalaMultibinderSpec extends WordSpec with Matchers {
 
     "bind [TypeLiteral]" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           val multi = ScalaMultibinder.newSetBinder(binder, typeLiteral[String])
           multi.addBinding.toInstance("A")
           multi.addBinding.toInstance("B")
@@ -49,7 +49,7 @@ class ScalaMultibinderSpec extends WordSpec with Matchers {
 
     "bind [Class]" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           val multi = ScalaMultibinder.newSetBinder(binder, classOf[String])
           multi.addBinding.toInstance("A")
           multi.addBinding.toInstance("B")
@@ -60,7 +60,7 @@ class ScalaMultibinderSpec extends WordSpec with Matchers {
 
     "bind [TypeLiteral, Annotation]" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           val multi = ScalaMultibinder.newSetBinder(binder, typeLiteral[String], annotation)
           multi.addBinding.toInstance("A")
           multi.addBinding.toInstance("B")
@@ -71,7 +71,7 @@ class ScalaMultibinderSpec extends WordSpec with Matchers {
 
     "bind [Class, Annotation]" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           val multi = ScalaMultibinder.newSetBinder(binder, classOf[String], annotation)
           multi.addBinding.toInstance("A")
           multi.addBinding.toInstance("B")
@@ -82,7 +82,7 @@ class ScalaMultibinderSpec extends WordSpec with Matchers {
 
     "bind [TypeLiteral, ClassAnnotation]" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           val multi = ScalaMultibinder.newSetBinder(binder, typeLiteral[String], classOf[Named])
           multi.addBinding.toInstance("A")
           multi.addBinding.toInstance("B")
@@ -94,7 +94,7 @@ class ScalaMultibinderSpec extends WordSpec with Matchers {
     "bind [Class, ClassAnnotation]" in {
       import com.google.inject.name.Named
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           val multi = ScalaMultibinder.newSetBinder(binder, classOf[String], classOf[Named])
           multi.addBinding.toInstance("A")
           multi.addBinding.toInstance("B")
@@ -105,23 +105,23 @@ class ScalaMultibinderSpec extends WordSpec with Matchers {
 
     "deduplicate" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           val multi = ScalaMultibinder.newSetBinder(binder, typeLiteral[Symbol])
-          multi.addBinding.toInstance('A)
-          multi.addBinding.toInstance('A)
+          multi.addBinding.toInstance(Symbol("A"))
+          multi.addBinding.toInstance(Symbol("A"))
         }
       }
-      validate(Guice.createInjector(module).instance[im.Set[Symbol]], 'A)
+      validate(Guice.createInjector(module).instance[im.Set[Symbol]], Symbol("A"))
     }
 
     "permit duplicates" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           val multi = ScalaMultibinder.newSetBinder(binder, typeLiteral[Symbol]).permitDuplicates()
-          multi.addBinding.toInstance('A)
+          multi.addBinding.toInstance(Symbol("A"))
         }
       }
-      validate(Guice.createInjector(module).instance[im.Set[Symbol]], 'A)
+      validate(Guice.createInjector(module).instance[im.Set[Symbol]], Symbol("A"))
     }
 
     "bind from multiple modules" in {
@@ -136,7 +136,7 @@ class ScalaMultibinderSpec extends WordSpec with Matchers {
 
     "bind deep parameterization in [Class]" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           val mbStrings = ScalaMultibinder.newSetBinder(binder, classOf[W[String]])
           mbStrings.addBinding.toInstance(W("A"))
           val mbInts = ScalaMultibinder.newSetBinder(binder, classOf[W[Int]])
@@ -151,7 +151,7 @@ class ScalaMultibinderSpec extends WordSpec with Matchers {
 
     "bind deep parameterization in [Class, Annotation]" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           val mbStrings = ScalaMultibinder.newSetBinder(binder, classOf[W[String]], annotation)
           mbStrings.addBinding.toInstance(W("A"))
           val mbInts = ScalaMultibinder.newSetBinder(binder, classOf[W[Int]], annotation)
@@ -166,7 +166,7 @@ class ScalaMultibinderSpec extends WordSpec with Matchers {
 
     "bind deep parameterization in [Class, ClassAnnotation]" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           val mbStrings = ScalaMultibinder.newSetBinder(binder, classOf[W[String]], classOf[Named])
           mbStrings.addBinding.toInstance(W("A"))
           val mbInts = ScalaMultibinder.newSetBinder(binder, classOf[W[Int]], classOf[Named])
@@ -181,7 +181,7 @@ class ScalaMultibinderSpec extends WordSpec with Matchers {
 
     "bind deep parameterization in [TypeLiteral]" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           val mbStrings = ScalaMultibinder.newSetBinder(binder, typeLiteral[W[String]])
           mbStrings.addBinding.toInstance(W("A"))
           val mbInts = ScalaMultibinder.newSetBinder(binder, typeLiteral[W[Int]])
@@ -196,7 +196,7 @@ class ScalaMultibinderSpec extends WordSpec with Matchers {
 
     "bind deep parameterization in [typeLiteral, Annotation]" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           val mbStrings = ScalaMultibinder.newSetBinder(binder, typeLiteral[W[String]], annotation)
           mbStrings.addBinding.toInstance(W("A"))
           val mbInts = ScalaMultibinder.newSetBinder(binder, typeLiteral[W[Int]], annotation)
@@ -211,7 +211,7 @@ class ScalaMultibinderSpec extends WordSpec with Matchers {
 
     "bind deep parameterization in [TypeLiteral, ClassAnnotation]" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           val mbStrings = ScalaMultibinder.newSetBinder(binder, typeLiteral[W[String]], classOf[Named])
           mbStrings.addBinding.toInstance(W("A"))
           val mbInts = ScalaMultibinder.newSetBinder(binder, typeLiteral[W[Int]], classOf[Named])
@@ -228,7 +228,7 @@ class ScalaMultibinderSpec extends WordSpec with Matchers {
 
     "bind [T]" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           val multi = ScalaMultibinder.newSetBinder[String](binder)
           multi.addBinding.toInstance("A")
           multi.addBinding.toInstance("B")
@@ -240,7 +240,7 @@ class ScalaMultibinderSpec extends WordSpec with Matchers {
     "bind [T, Ann]" in {
       import com.google.inject.name.Named
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           val multi = ScalaMultibinder.newSetBinder[String, Named](binder)
           multi.addBinding.toInstance("A")
           multi.addBinding.toInstance("B")
@@ -251,7 +251,7 @@ class ScalaMultibinderSpec extends WordSpec with Matchers {
 
     "bind [T](Ann)" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           val multi = ScalaMultibinder.newSetBinder[String](binder, annotation)
           multi.addBinding.toInstance("A")
           multi.addBinding.toInstance("B")
@@ -262,7 +262,7 @@ class ScalaMultibinderSpec extends WordSpec with Matchers {
 
     "bind deep parameterization in [T]" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           val mbStrings = ScalaMultibinder.newSetBinder[W[String]](binder)
           mbStrings.addBinding.toInstance(W("A"))
           val mbInts = ScalaMultibinder.newSetBinder[W[Int]](binder)
@@ -277,7 +277,7 @@ class ScalaMultibinderSpec extends WordSpec with Matchers {
 
     "bind deep parameterization in [T, Ann]" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           val mbStrings = ScalaMultibinder.newSetBinder[W[String], Named](binder)
           mbStrings.addBinding.toInstance(W("A"))
           val mbInts = ScalaMultibinder.newSetBinder[W[Int], Named](binder)
@@ -292,7 +292,7 @@ class ScalaMultibinderSpec extends WordSpec with Matchers {
 
     "bind deep parameterization in [T](annotation)" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           val mbStrings = ScalaMultibinder.newSetBinder[W[String]](binder, annotation)
           mbStrings.addBinding.toInstance(W("A"))
           val mbInts = ScalaMultibinder.newSetBinder[W[Int]](binder, annotation)

--- a/src/test/scala/net/codingwell/scalaguice/ScalaOptionBinderSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/ScalaOptionBinderSpec.scala
@@ -15,17 +15,17 @@
  */
 package net.codingwell.scalaguice
 
-import java.lang.annotation.Annotation
-
 import com.google.common.base.Optional
 import com.google.inject.name.{Named, Names}
 import com.google.inject.{AbstractModule, Guice, Key, Module, Provider}
+import java.lang.annotation.Annotation
 import net.codingwell.scalaguice.InjectorExtensions._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 
-class ScalaOptionBinderSpec extends WordSpec with Matchers {
+class ScalaOptionBinderSpec extends AnyWordSpec with Matchers {
   private case class W[T](t: T)
   private val annotation = Names.named("N")
 

--- a/src/test/scala/net/codingwell/scalaguice/ScalaPrivateModuleSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/ScalaPrivateModuleSpec.scala
@@ -15,17 +15,17 @@
  */
 package net.codingwell.scalaguice
 
-import org.scalatest.{Matchers, WordSpec}
-
 import com.google.inject._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ScalaPrivateModuleSpec extends WordSpec with Matchers {
+class ScalaPrivateModuleSpec extends AnyWordSpec with Matchers {
 
   "A Scala Guice private module" should {
 
     "allow binding source type using a type parameter" in {
       val module = new PrivateModule with ScalaPrivateModule {
-        def configure() = {
+        def configure(): Unit = {
           bind[A].to(classOf[B])
           expose[A]
         }
@@ -35,7 +35,7 @@ class ScalaPrivateModuleSpec extends WordSpec with Matchers {
 
     "allow binding target type using a type parameter" in {
       val module = new PrivateModule with ScalaPrivateModule {
-        def configure() = {
+        def configure(): Unit = {
           bind[A].to[B]
           expose[A]
         }
@@ -45,7 +45,7 @@ class ScalaPrivateModuleSpec extends WordSpec with Matchers {
 
     "allow binding target provider type using a type parameter" in {
       val module = new PrivateModule with ScalaPrivateModule {
-        def configure() = {
+        def configure(): Unit = {
           bind[A].toProvider[BProvider]
           expose[A]
         }
@@ -55,7 +55,7 @@ class ScalaPrivateModuleSpec extends WordSpec with Matchers {
 
     "allow binding to provider of subtype using type parameter" in {
       val module = new PrivateModule with ScalaPrivateModule {
-        def configure() = {
+        def configure(): Unit = {
           bind[Gen[String]].toProvider[CProvider]
           expose[Gen[String]]
         }
@@ -65,7 +65,7 @@ class ScalaPrivateModuleSpec extends WordSpec with Matchers {
 
     "allow binding to provider with injected type literal" in {
       val module = new PrivateModule with ScalaPrivateModule {
-        def configure() = {
+        def configure(): Unit = {
           bind[String].toProvider[TypeProvider[B]]
           expose[String]
         }
@@ -75,8 +75,8 @@ class ScalaPrivateModuleSpec extends WordSpec with Matchers {
 
     "allow binding in scope using a type parameter" in {
       val module = new PrivateModule with ScalaPrivateModule {
-        def configure() = {
-          bind[A].to[B].in[Singleton]
+        def configure(): Unit = {
+          bind[A].to[B].in[Singleton]()
           expose[A]
         }
       }
@@ -86,9 +86,9 @@ class ScalaPrivateModuleSpec extends WordSpec with Matchers {
     "allow binding with annotation using a type parameter" in {
       import name.Named
       val module = new PrivateModule with ScalaPrivateModule {
-        def configure() = {
+        def configure(): Unit = {
           bind[A].annotatedWith[Named].to[B]
-          expose[A].annotatedWith[Named]
+          expose[A].annotatedWith[Named]()
         }
       }
       Guice.createInjector(module).getInstance(Key.get(classOf[A],classOf[Named]))
@@ -96,7 +96,7 @@ class ScalaPrivateModuleSpec extends WordSpec with Matchers {
 
     "give a useful error when bound on itself" in {
       val module = new PrivateModule with ScalaPrivateModule {
-        def configure() = {
+        def configure(): Unit = {
           bind[A].to[A]
           expose[A]
         }

--- a/src/test/scala/net/codingwell/scalaguice/SetProviderSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/SetProviderSpec.scala
@@ -15,15 +15,13 @@
  */
 package net.codingwell.scalaguice
 
-import org.scalatest.{Matchers, WordSpec}
-
 import com.google.inject._
+import java.util.{HashSet => JHashSet, Set => JSet}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import scala.collection.{immutable => im}
 
-import java.util.{Set => JSet, HashSet => JHashSet}
-
-import scala.collection.{ immutable => im }
-
-class SetProviderSpec extends WordSpec with Matchers {
+class SetProviderSpec extends AnyWordSpec with Matchers {
 
   private val testSet = newSet(1, 3)
 
@@ -31,28 +29,28 @@ class SetProviderSpec extends WordSpec with Matchers {
 
     "allow binding a Java Set" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           bind[JSet[B]].toInstance( new JHashSet[B]() )
           bind[im.Set[B]].toProvider( new SetProvider( Key.get( typeLiteral[JSet[B]] ) ) )
         }
       }
-      Guice.createInjector(module).getInstance( Key.get( typeLiteral[im.Set[B]] )) should be ('empty)
+      Guice.createInjector(module).getInstance( Key.get( typeLiteral[im.Set[B]] )) should be (Symbol("empty"))
     }
 
     "allow binding a Java Set with a Java annotation" in {
       import name.Named
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           bind[JSet[B]].annotatedWith[Named].toInstance( new JHashSet[B]() )
           bind[im.Set[B]].annotatedWith[Named].toProvider( new SetProvider( Key.get( typeLiteral[JSet[B]], classOf[Named] ) ) )
         }
       }
-      Guice.createInjector(module).getInstance( Key.get( typeLiteral[im.Set[B]],classOf[Named])) should be ('empty)
+      Guice.createInjector(module).getInstance( Key.get( typeLiteral[im.Set[B]],classOf[Named])) should be (Symbol("empty"))
     }
 
     "allow binding a Java Set with data" in {
       val module = new AbstractModule with ScalaModule {
-        override def configure() = {
+        override def configure(): Unit = {
           bind[JSet[Int]].toInstance( testSet )
           bind[im.Set[Int]].toProvider( new SetProvider( Key.get( typeLiteral[JSet[Int]] ) ) )
         }

--- a/src/test/scala/net/codingwell/scalaguice/TypeLiteralSpec.scala
+++ b/src/test/scala/net/codingwell/scalaguice/TypeLiteralSpec.scala
@@ -16,9 +16,10 @@
 package net.codingwell.scalaguice
 
 import net.codingwell.scalaguice.Testing.SomeClazzWithAugmentation
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class TypeLiteralSpec extends FunSpec with Matchers {
+class TypeLiteralSpec extends AnyFunSpec with Matchers {
 
   import com.google.inject._
 


### PR DESCRIPTION
Problem

In order to prepare for the transition to Scala 3, it is helpful to move to support
Scala 2.13.6 which is [compatible with Scala 3](https://github.com/scala/scala/releases/tag/v2.13.6).

Solution

Update the default Scala version of the project to Scala 2.13.6. We maintain all 
the previous cross compilation versions (bumping to Scala 2.13.6 here as well)
so this should not have a material impact.

In order to support the lower versions we tee-code into version compatibility
directories with the idea that at some point the `src/main/scala-2.12-` source
directory will be dropped and the `src/main/scala-2.13+` directory can
be folded back into `src/main/scala`. This has no impact on library users only on
maintainers and contributors. 

Code which uses 2.13+ features is in `src/main/scala-2.13+` and code which doesn't 
work with 2.13 is in `src/main/scala-2.12-`. The majority of the code is agnostic and 
remains in `src/main/scala` with changes made in some cases to make the code agnostic 
to Scala version (removal of Proxy usage in `BindingProxies`, removal of `.mapValues` 
usage in `ScalaMapBinderSpec`).

Lastly, a bit of clean up: 
- update scalatest to the latest version and update tests to non-deprecated `AnyFunSpec`, `AnyWordSpec` and the should `Matchers`.
- add return types to most public methods and members
- clean up and format imports
