### PR TITLE
Update guice dependency version to 5.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ licenses := Seq("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.
 homepage := Some(url("https://github.com/codingwell/scala-guice"))
 
 libraryDependencies ++= Seq(
-  "com.google.inject" % "guice" % "5.0.1",
+  "com.google.inject" % "guice" % "5.1.0",
   "org.scala-lang" % "scala-reflect" % scalaVersion.value
 )
 


### PR DESCRIPTION
Hello!  I'm having trouble with runtime classpath conflicts with Guava and Guice versions
```
scala> val bc = BiojavaAdamContext(sc)
java.lang.NoSuchMethodError:
'com.google.common.base.Stopwatch com.google.common.base.Stopwatch.createUnstarted()'
  at com.google.inject.internal.InternalInjectorCreator.<init>(InternalInjectorCreator.java:64)
  at com.google.inject.Guice.createInjector(Guice.java:87)
  at com.google.inject.Guice.createInjector(Guice.java:69)
  at com.google.inject.Guice.createInjector(Guice.java:59)
  at org.biojava.nbio.adam.BiojavaAdamContext$.apply(BiojavaAdamContext.scala:93)
  ... 47 elided
```

and haven't been able to determine the right combination of shading & relocating to make it work
```
java.lang.NoClassDefFoundError:
org/biojava/nbio/adam/shaded/net/codingwell/scalaguice/InjectorExtensions$ScalaInjector$
  at org.biojava.nbio.adam.BiojavaAdamContext$.apply(BiojavaAdamContext.scala:94)
  ... 47 elided
Caused by: java.lang.ClassNotFoundException:
org.biojava.nbio.adam.shaded.net.codingwell.scalaguice.InjectorExtensions$ScalaInjector$
  at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:476)
  at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589)
  at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
  ... 48 more
```

Hopefully updating scala-guice to use version 5.1.0 of Guice will alleviate this issue.  Thank you!